### PR TITLE
Update template README.md

### DIFF
--- a/cmd/init/templates/README.md
+++ b/cmd/init/templates/README.md
@@ -7,4 +7,4 @@ TODO: Describe the approach that was used to select repositories for this change
 TODO: Describe any shell commands, scripts, manual operations, etc, that were used to make changes
 
 <!-- Please keep the footer below, to support turbolift usage tracking -->
-<sub>This PR was generated using [turbolift](https://github.skyscannertools.net/mshell/turbolift/).</sub>
+<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>


### PR DESCRIPTION
Template README currently points to an internal version of turbolift, should point to the open-source `github.com` version.