### PR TITLE
Add git clone command

### DIFF
--- a/internal/github/fake_github.go
+++ b/internal/github/fake_github.go
@@ -38,6 +38,12 @@ func (f *FakeGitHub) ForkAndClone(output io.Writer, workingDir string, fullRepoN
 	return err
 }
 
+func (f *FakeGitHub) Clone(output io.Writer, workingDir string, fullRepoName string) error {
+	f.calls = append(f.calls, []string{workingDir, fullRepoName})
+	_, err := f.handler(output, workingDir, fullRepoName)
+	return err
+}
+
 func (f *FakeGitHub) AssertCalledWith(t *testing.T, expected [][]string) {
 	assert.Equal(t, expected, f.calls)
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -31,6 +31,7 @@ type PullRequest struct {
 
 type GitHub interface {
 	ForkAndClone(output io.Writer, workingDir string, fullRepoName string) error
+	Clone(output io.Writer, workingDir string, fullRepoName string) error
 	CreatePullRequest(output io.Writer, workingDir string, metadata PullRequest) (didCreate bool, err error)
 }
 
@@ -52,6 +53,10 @@ func (r *RealGitHub) CreatePullRequest(output io.Writer, workingDir string, pr P
 
 func (r *RealGitHub) ForkAndClone(output io.Writer, workingDir string, fullRepoName string) error {
 	return execInstance.Execute(output, workingDir, "gh", "repo", "fork", "--clone=true", fullRepoName)
+}
+
+func (r *RealGitHub) Clone(output io.Writer, workingDir string, fullRepoName string) error {
+	return execInstance.Execute(output, workingDir, "gh", "repo", "clone", fullRepoName)
 }
 
 func NewRealGitHub() *RealGitHub {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -47,6 +47,30 @@ func TestItReturnsNilErrorOnSuccessfulFork(t *testing.T) {
 	})
 }
 
+func TestItReturnsErrorOnFailedClone(t *testing.T) {
+	fakeExecutor := executor.NewAlwaysFailsFakeExecutor()
+	execInstance = fakeExecutor
+
+	_, err := runCloneAndCaptureOutput()
+	assert.Error(t, err)
+
+	fakeExecutor.AssertCalledWith(t, [][]string{
+		{"work/org", "gh", "repo", "clone", "org/repo1"},
+	})
+}
+
+func TestItReturnsNilErrorOnSuccessfulClone(t *testing.T) {
+	fakeExecutor := executor.NewAlwaysSucceedsFakeExecutor()
+	execInstance = fakeExecutor
+
+	_, err := runCloneAndCaptureOutput()
+	assert.NoError(t, err)
+
+	fakeExecutor.AssertCalledWith(t, [][]string{
+		{"work/org", "gh", "repo", "clone", "org/repo1"},
+	})
+}
+
 func TestItReturnsErrorOnFailedCreatePr(t *testing.T) {
 	fakeExecutor := executor.NewAlwaysFailsFakeExecutor()
 	execInstance = fakeExecutor
@@ -93,6 +117,13 @@ func TestItReturnsTrueAndNilErrorOnSuccessfulCreatePr(t *testing.T) {
 func runForkAndCloneAndCaptureOutput() (string, error) {
 	sb := strings.Builder{}
 	err := NewRealGitHub().ForkAndClone(&sb, "work/org", "org/repo1")
+
+	return sb.String(), err
+}
+
+func runCloneAndCaptureOutput() (string, error) {
+	sb := strings.Builder{}
+	err := NewRealGitHub().Clone(&sb, "work/org", "org/repo1")
 
 	return sb.String(), err
 }


### PR DESCRIPTION
Partially addresses #48 

This makes no actual changes to any commands, but adds the ability to call `Clone` function.

As there is still some ambiguity around how we should address the actual `turbolift clone` command, I will address that in a followup PR.

@sledigabel @rnorth  would you prefer to preserve current behaviour in `clone.go` to fork by default? I think not forking by default is more user-friendly in general, but it sounds like the Skyscanner use case requires bulk forking. 

My suggestion would be to make the new Clone command default, and place `ForkAndClone` behind a different cobra command.