### PR TITLE
Disabling all arguments after foreach

### DIFF
--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -29,10 +29,11 @@ var exec executor.Executor = executor.NewRealExecutor()
 
 func NewForeachCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "foreach -- SHELL_COMMAND",
-		Short: "Run a shell command against each working copy",
-		Run:   run,
-		Args:  cobra.MinimumNArgs(1),
+		Use:                "foreach -- SHELL_COMMAND",
+		Short:              "Run a shell command against each working copy",
+		Run:                run,
+		Args:               cobra.MinimumNArgs(1),
+		DisableFlagParsing: true,
 	}
 
 	return cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,10 +32,11 @@ var commit = "commit-dev"
 var date = "date-dev"
 
 var rootCmd = &cobra.Command{
-	Use:     "turbolift",
-	Short:   "Turbolift",
-	Long:    `Mass refactoring tool for repositories in GitHub`,
-	Version: fmt.Sprintf("%s (%s, built %s)", version, commit, date),
+	Use:              "turbolift",
+	Short:            "Turbolift",
+	Long:             `Mass refactoring tool for repositories in GitHub`,
+	Version:          fmt.Sprintf("%s (%s, built %s)", version, commit, date),
+	TraverseChildren: true,
 }
 
 func init() {


### PR DESCRIPTION
Fixes #50.
Uses `DisableFlagParsing` as per the documentation to disable the
subsequent flag parsing in the command and leaving it as arguments to
the shell command.

Added `TraverseChildren` to rootCmd to allow -v and -h to be parsed.

https://pkg.go.dev/github.com/spf13/cobra#Command

Tested on Mac OS.

I'm unable to write tests as we're not testing the flag parsing at the
moment.