### PR TITLE
Ignore duplicated repos

### DIFF
--- a/internal/campaign/campaign.go
+++ b/internal/campaign/campaign.go
@@ -73,10 +73,16 @@ func readReposTxtFile() ([]Repo, error) {
 	}()
 
 	scanner := bufio.NewScanner(file)
+	uniq := map[string]interface{}{}
 	var repos []Repo
 	for scanner.Scan() {
 		line := scanner.Text()
 		if !strings.HasPrefix(line, "#") && len(line) > 0 {
+			if _, seen := uniq[line]; seen {
+				continue
+			}
+			uniq[line] = struct{}{}
+
 			splitLine := strings.Split(line, "/")
 			numParts := len(splitLine)
 

--- a/internal/campaign/campaign_test.go
+++ b/internal/campaign/campaign_test.go
@@ -127,3 +127,41 @@ func TestItIgnoresEmptyAndCommentedLines(t *testing.T) {
 	assert.Equal(t, campaign.PrTitle, "PR title")
 	assert.Equal(t, campaign.PrBody, "PR body")
 }
+
+func TestItIgnoresDuplicatedLines(t *testing.T) {
+	testsupport.PrepareTempCampaign(false, "org/repo1", "org/repo1")
+
+	campaign, err := OpenCampaign()
+	assert.NoError(t, err)
+
+	assert.Equal(t, []Repo{
+		{
+			Host:         "",
+			OrgName:      "org",
+			RepoName:     "repo1",
+			FullRepoName: "org/repo1",
+		},
+	}, campaign.Repos)
+}
+
+func TestItIgnoresDuplicatedNonSequentialLines(t *testing.T) {
+	testsupport.PrepareTempCampaign(false, "org/repo1", "org/repo2", "org/repo1")
+
+	campaign, err := OpenCampaign()
+	assert.NoError(t, err)
+
+	assert.Equal(t, []Repo{
+		{
+			Host:         "",
+			OrgName:      "org",
+			RepoName:     "repo1",
+			FullRepoName: "org/repo1",
+		},
+		{
+			Host:         "",
+			OrgName:      "org",
+			RepoName:     "repo2",
+			FullRepoName: "org/repo2",
+		},
+	}, campaign.Repos)
+}


### PR DESCRIPTION
Fixes #52

- added a simple hashset check on a line
- added tests for sequential and non-sequential lines

p.s. found that `assert.Equal` has expected arg as a first one. This is not the case in campaign tests, which is slightly confusing on test fails, thus changed an order in my new tests.