### PR TITLE
Adding a `--draft` flag on the `pr-create` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Use `turbolift create-prs --sleep 30s` to, for example, force a 30s pause betwee
 > Important: if raising many PRs, you may generate load on shared infrastucture such as CI. It is *highly* recommended that you:
 > * slow the rate of PR creation by making Turbolift sleep in between PRs
 > * create PRs in batches, for example by commenting out repositories in `repos.txt`
+> * Use the `--draft` flag to create the PRs as Draft
 
 If you need to mass-close PRs, it is easy to do using `turbolift foreach` and the `gh` GitHub CLI ([docs](https://cli.github.com/manual/gh_pr_close)):
 

--- a/cmd/create_prs/create_prs_test.go
+++ b/cmd/create_prs/create_prs_test.go
@@ -85,8 +85,42 @@ func TestItLogsCreatePrsSucceeds(t *testing.T) {
 	})
 }
 
+func TestItLogsCreateDraftPr(t *testing.T) {
+	fakeGitHub := github.NewAlwaysSucceedsFakeGitHub()
+	gh = fakeGitHub
+	fakeGit := git.NewAlwaysSucceedsFakeGit()
+	g = fakeGit
+
+	testsupport.PrepareTempCampaign(true, "org/repo1", "org/repo2")
+
+	out, err := runCommandDraft()
+	assert.NoError(t, err)
+	assert.Contains(t, out, "Creating Draft PR in org/repo1")
+	assert.Contains(t, out, "Creating Draft PR in org/repo2")
+	assert.Contains(t, out, "turbolift create-prs completed")
+	assert.Contains(t, out, "2 OK, 0 skipped")
+
+	fakeGitHub.AssertCalledWith(t, [][]string{
+		{"work/org/repo1", "PR title"},
+		{"work/org/repo2", "PR title"},
+	})
+}
+
 func runCommand() (string, error) {
 	cmd := NewCreatePRsCmd()
+	outBuffer := bytes.NewBufferString("")
+	cmd.SetOut(outBuffer)
+	err := cmd.Execute()
+
+	if err != nil {
+		return outBuffer.String(), err
+	}
+	return outBuffer.String(), nil
+}
+
+func runCommandDraft() (string, error) {
+	cmd := NewCreatePRsCmd()
+	isDraft = true
 	outBuffer := bytes.NewBufferString("")
 	cmd.SetOut(outBuffer)
 	err := cmd.Execute()

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -27,6 +27,7 @@ type PullRequest struct {
 	Title        string
 	Body         string
 	UpstreamRepo string
+	IsDraft      bool
 }
 
 type GitHub interface {
@@ -38,8 +39,22 @@ type RealGitHub struct {
 }
 
 func (r *RealGitHub) CreatePullRequest(output io.Writer, workingDir string, pr PullRequest) (didCreate bool, err error) {
-	execOutput, err := execInstance.ExecuteAndCapture(output, workingDir, "gh", "pr", "create", "--title", pr.Title, "--body", pr.Body, "--repo", pr.UpstreamRepo)
+	gh_args := []string{
+		"pr",
+		"create",
+		"--title",
+		pr.Title,
+		"--body",
+		pr.Body,
+		"--repo",
+		pr.UpstreamRepo,
+	}
 
+	if pr.IsDraft {
+		gh_args = append(gh_args, "--draft")
+	}
+
+	execOutput, err := execInstance.ExecuteAndCapture(output, workingDir, "gh", gh_args...)
 	if strings.Contains(execOutput, "GraphQL error: No commits between") {
 		// no PR was created because there are no differences between remotes
 		return false, nil

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -77,6 +77,19 @@ func TestItReturnsFalseAndNilErrorOnNoOpCreatePr(t *testing.T) {
 	})
 }
 
+func TestItSuccessfulCreatesADraftPr(t *testing.T) {
+	fakeExecutor := executor.NewAlwaysSucceedsFakeExecutor()
+	execInstance = fakeExecutor
+
+	didCreatePr, _, err := runCreateDraftPrAndCaptureOutput()
+	assert.NoError(t, err)
+	assert.True(t, didCreatePr)
+
+	fakeExecutor.AssertCalledWith(t, [][]string{
+		{"work/org/repo1", "gh", "pr", "create", "--title", "some title", "--body", "some body", "--repo", "org/repo1", "--draft"},
+	})
+}
+
 func TestItReturnsTrueAndNilErrorOnSuccessfulCreatePr(t *testing.T) {
 	fakeExecutor := executor.NewAlwaysSucceedsFakeExecutor()
 	execInstance = fakeExecutor
@@ -103,6 +116,18 @@ func runCreatePrAndCaptureOutput() (bool, string, error) {
 		Title:        "some title",
 		Body:         "some body",
 		UpstreamRepo: "org/repo1",
+	})
+
+	return didCreatePr, sb.String(), err
+}
+
+func runCreateDraftPrAndCaptureOutput() (bool, string, error) {
+	sb := strings.Builder{}
+	didCreatePr, err := NewRealGitHub().CreatePullRequest(&sb, "work/org/repo1", PullRequest{
+		Title:        "some title",
+		Body:         "some body",
+		UpstreamRepo: "org/repo1",
+		IsDraft:      true,
 	})
 
 	return didCreatePr, sb.String(), err


### PR DESCRIPTION
This allows the user to create multiple Pull Requests as _Draft_, which
notifies the recipient that more work is coming and the PR is not ready
for review as is.

Addresses #11.

Another PR is coming to allow users to move all the PRs to "ready" using the `gh pr ready` command.