### PR TITLE
Adds the ability to clone only and not fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Making changes with turbolift is split into six main phases:
 
 1. `init` - getting set up
 2. Identifying the repos to operate upon
-3. Running a mass `clone` of the repos (which creates a fork in your user space if you don't have permissions on the repository)
+3. Running a mass `clone` of the repos (by default, it will create a fork in your user space)
 4. Making changes to every repo
 5. Committing changes to every repo
 6. Creating a PR for every repo
@@ -92,7 +92,10 @@ $ gh-search --repos-with-matches YOUR_GITHUB_CODE_SEARCH_QUERY > repos.txt
 
 ```turbolift clone```
 
-This clones all repositories listed in the `repos.txt` file into the `work` directory.
+This creates a fork and clones all repositories listed in the `repos.txt` file into the `work` directory.
+You may wish to skip the fork and work on the upstream repository branch directly with the flag `--no-fork`.
+
+> NTLD: if one of the repositories in the list requires a fork to create a PR, omit the `--no-fork` flag and let all the repositories be forked. For now it's a all-or-nothing scenario.
 
 ### Making changes
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Anyone who has had to manually make changes to many GitHub repositories knows th
 
 It's dumb but it works. It doesn't scale well, though. Manually cloning and raising PRs against tens/hundreds of repositories is painful and boring.
 
-Turbolift essentially automates the boring parts and stays out of the way when it comes to actually making the changes. It automates forking, cloning, committing, and raising PRs en-masse, so that you can focus on the substance of the change.
+Turbolift essentially automates the boring parts and stays out of the way when it comes to actually making the changes. It automates cloning, committing, and raising PRs en-masse, so that you can focus on the substance of the change.
 
 > Historical note: Turbolift supersedes an internal system at Skyscanner named Codelift. Codelift was a centralised batch system, requiring changes to be scripted upfront and run overnight. While Codelift was useful, we have found that a decentralised, interactive tool is far easier and quicker for people to use in practice. 
 
@@ -38,7 +38,7 @@ Making changes with turbolift is split into six main phases:
 
 1. `init` - getting set up
 2. Identifying the repos to operate upon
-3. Running a mass `clone` of the repos (which automatically creates a fork in your user space)
+3. Running a mass `clone` of the repos (which creates a fork in your user space if you don't have permissions on the repository)
 4. Making changes to every repo
 5. Committing changes to every repo
 6. Creating a PR for every repo

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -29,12 +29,16 @@ import (
 var gh github.GitHub = github.NewRealGitHub()
 var g git.Git = git.NewRealGit()
 
+var fork bool
+
 func NewCloneCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "clone",
 		Short: "Clone all repositories",
 		Run:   run,
 	}
+
+	cmd.Flags().BoolVar(&fork, "fork", false, "Force forking even if the user has push rights on the repository.")
 
 	return cmd
 }
@@ -54,11 +58,16 @@ func run(c *cobra.Command, _ []string) {
 	for _, repo := range dir.Repos {
 		orgDirPath := path.Join("work", repo.OrgName) // i.e. work/org
 
-		forkCloneActivity := logger.StartActivity("Forking and cloning %s into %s/%s", repo.FullRepoName, orgDirPath, repo.RepoName)
+		var cloneActivity *logging.Activity
+		if fork {
+			cloneActivity = logger.StartActivity("Forking and cloning %s into %s/%s", repo.FullRepoName, orgDirPath, repo.RepoName)
+		} else {
+			cloneActivity = logger.StartActivity("Cloning %s into %s/%s", repo.FullRepoName, orgDirPath, repo.RepoName)
+		}
 
 		err := os.MkdirAll(orgDirPath, os.ModeDir|0755)
 		if err != nil {
-			forkCloneActivity.EndWithFailuref("Unable to create org directory: %s", err)
+			cloneActivity.EndWithFailuref("Unable to create org directory: %s", err)
 			errorCount++
 			break
 		}
@@ -66,19 +75,24 @@ func run(c *cobra.Command, _ []string) {
 		repoDirPath := path.Join(orgDirPath, repo.RepoName) // i.e. work/org/repo
 		// skip if the working copy is already cloned
 		if _, err = os.Stat(repoDirPath); !os.IsNotExist(err) {
-			forkCloneActivity.EndWithWarningf("Directory already exists")
+			cloneActivity.EndWithWarningf("Directory already exists")
 			skippedCount++
 			continue
 		}
 
-		err = gh.ForkAndClone(forkCloneActivity.Writer(), orgDirPath, repo.FullRepoName)
+		if fork {
+			err = gh.ForkAndClone(cloneActivity.Writer(), orgDirPath, repo.FullRepoName)
+		} else {
+			err = gh.Clone(cloneActivity.Writer(), orgDirPath, repo.FullRepoName)
+		}
+
 		if err != nil {
-			forkCloneActivity.EndWithFailure(err)
+			cloneActivity.EndWithFailure(err)
 			errorCount++
 			continue
 		}
 
-		forkCloneActivity.EndWithSuccess()
+		cloneActivity.EndWithSuccess()
 
 		createBranchActivity := logger.StartActivity("Creating branch %s in %s", dir.Name, repo.FullRepoName)
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -16,9 +16,10 @@
 package github
 
 import (
-	"github.com/skyscanner/turbolift/internal/executor"
 	"io"
 	"strings"
+
+	"github.com/skyscanner/turbolift/internal/executor"
 )
 
 var execInstance executor.Executor = executor.NewRealExecutor()


### PR DESCRIPTION
This is a follow up of #49.

With this commit, the `clone` command is defaulting to cloning and
forking only when the user has not push rights onto the repository.

If the `--fork` flag is specified, it will fork and clone
systematically.