### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2.5.2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.39.0
+          version: v1.42.1
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ARCH=$(shell uname -m)
 VERSION=0.0.1
 ITERATION := 1
 
-GOLANGCI_VERSION = 1.32.0
+GOLANGCI_VERSION = 1.42.1
 
 BIN_DIR := $(CURDIR)/bin
 


### PR DESCRIPTION
Among other things, a newer version of golangci-lint is required to allow the project to be built on an M1 Mac 😄 