### PR TITLE
Using filepath instead of path

### DIFF
--- a/cmd/init/init.go
+++ b/cmd/init/init.go
@@ -18,12 +18,13 @@ package init
 import (
 	_ "embed"
 	"fmt"
-	"github.com/skyscanner/turbolift/internal/colors"
-	"github.com/skyscanner/turbolift/internal/logging"
-	"github.com/spf13/cobra"
 	"html/template"
 	"os"
 	"path/filepath"
+
+	"github.com/skyscanner/turbolift/internal/colors"
+	"github.com/skyscanner/turbolift/internal/logging"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -103,19 +104,19 @@ func run(c *cobra.Command, _ []string) {
 func applyTemplate(outputFilename string, templateContent string, data interface{}) error {
 	readme, err := os.Create(outputFilename)
 	if err != nil {
-		return fmt.Errorf("Unable to open file for output: %w", err)
+		return fmt.Errorf("unable to open file for output: %w", err)
 	}
 
 	parsedTemplate, err := template.New("").Parse(templateContent)
 
 	if err != nil {
-		return fmt.Errorf("Unable to parse template: %w", err)
+		return fmt.Errorf("unable to parse template: %w", err)
 	}
 
 	err = parsedTemplate.Execute(readme, data)
 
 	if err != nil {
-		return fmt.Errorf("Unable to write templated file: %w", err)
+		return fmt.Errorf("unable to write templated file: %w", err)
 	}
 	return nil
 }

--- a/internal/campaign/campaign.go
+++ b/internal/campaign/campaign.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -40,7 +40,7 @@ type Campaign struct {
 
 func OpenCampaign() (*Campaign, error) {
 	dir, _ := os.Getwd()
-	dirBasename := path.Base(dir)
+	dirBasename := filepath.Base(dir)
 
 	repos, err := readReposTxtFile()
 	if err != nil {
@@ -63,7 +63,7 @@ func OpenCampaign() (*Campaign, error) {
 func readReposTxtFile() ([]Repo, error) {
 	file, err := os.Open("repos.txt")
 	if err != nil {
-		return nil, errors.New("Unable to open repos.txt file")
+		return nil, errors.New("unable to open repos.txt file")
 	}
 	defer func() {
 		closeErr := file.Close()
@@ -101,14 +101,14 @@ func readReposTxtFile() ([]Repo, error) {
 					FullRepoName: line,
 				}
 			} else {
-				return nil, fmt.Errorf("Unable to parse entry in repos.txt file: %s", line)
+				return nil, fmt.Errorf("unable to parse entry in repos.txt file: %s", line)
 			}
 			repos = append(repos, repo)
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("Unable to open repos.txt file: %w", err)
+		return nil, fmt.Errorf("unable to open repos.txt file: %w", err)
 	}
 
 	return repos, nil
@@ -117,7 +117,7 @@ func readReposTxtFile() ([]Repo, error) {
 func readPrDescriptionFile() (string, string, error) {
 	file, err := os.Open("README.md")
 	if err != nil {
-		return "", "", errors.New("Unable to open README.md file")
+		return "", "", errors.New("unable to open README.md file")
 	}
 	defer func() {
 		closeErr := file.Close()
@@ -141,7 +141,7 @@ func readPrDescriptionFile() (string, string, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return "", "", errors.New("Unable to read README.md file")
+		return "", "", errors.New("unable to read README.md file")
 	}
 
 	return prTitle, strings.Join(prBodyLines, "\n"), nil

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -67,7 +67,7 @@ func (e *RealExecutor) ExecuteAndCapture(output io.Writer, workingDir string, na
 	if err != nil {
 		if exitErr, _ := err.(*exec.ExitError); exitErr != nil {
 			stdErr := string(exitErr.Stderr)
-			return stdErr, fmt.Errorf("Error: %w. Stderr: %s", exitErr, stdErr)
+			return stdErr, fmt.Errorf("error: %w. Stderr: %s", exitErr, stdErr)
 		}
 		return string(commandOutput), err
 	}

--- a/internal/testsupport/testsupport.go
+++ b/internal/testsupport/testsupport.go
@@ -19,12 +19,13 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
 func Pwd() string {
 	dir, _ := os.Getwd()
-	return path.Base(dir)
+	return filepath.Base(dir)
 }
 
 func CreateAndEnterTempDirectory() {


### PR DESCRIPTION
Fixes #69.

the `path` package is not dealing with Windows and needed to be replaced
with `filepath`. https://pkg.go.dev/path#pkg-overview

Also fixed a few linting errors from my golang-ci parser:
https://github.com/golang/go/wiki/CodeReviewComments#error-strings