### PR TITLE
Optional repo file

### DIFF
--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -27,10 +27,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var gh github.GitHub = github.NewRealGitHub()
-var g git.Git = git.NewRealGit()
+var (
+	gh github.GitHub = github.NewRealGitHub()
+	g  git.Git       = git.NewRealGit()
+)
 
-var nofork bool
+var (
+	nofork   bool
+	repoFile string
+)
 
 func NewCloneCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -40,6 +45,7 @@ func NewCloneCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVar(&nofork, "no-fork", false, "Will not fork, just clone and create a branch.")
+	cmd.Flags().StringVar(&repoFile, "repos", "repos.txt", "A file containing a list of repositories to clone.")
 
 	return cmd
 }
@@ -48,7 +54,9 @@ func run(c *cobra.Command, _ []string) {
 	logger := logging.NewLogger(c)
 
 	readCampaignActivity := logger.StartActivity("Reading campaign data")
-	dir, err := campaign.OpenCampaign()
+	defaultOptions := campaign.NewCampaignOptions()
+	defaultOptions.RepoFilename = repoFile
+	dir, err := campaign.OpenCampaign(defaultOptions)
 	if err != nil {
 		readCampaignActivity.EndWithFailure(err)
 		return

--- a/cmd/commit/commit.go
+++ b/cmd/commit/commit.go
@@ -16,18 +16,22 @@
 package commit
 
 import (
+	"os"
+	"path"
+
 	"github.com/skyscanner/turbolift/internal/campaign"
 	"github.com/skyscanner/turbolift/internal/colors"
 	"github.com/skyscanner/turbolift/internal/git"
 	"github.com/skyscanner/turbolift/internal/logging"
 	"github.com/spf13/cobra"
-	"os"
-	"path"
 )
 
 var g git.Git = git.NewRealGit()
 
-var message string
+var (
+	message  string
+	repoFile string
+)
 
 func NewCommitCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,6 +41,8 @@ func NewCommitCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&message, "message", "m", "", "Commit message to apply")
+	cmd.Flags().StringVar(&repoFile, "repos", "repos.txt", "A file containing a list of repositories to clone.")
+
 	err := cmd.MarkFlagRequired("message")
 	if err != nil {
 		panic(err)
@@ -49,7 +55,9 @@ func run(c *cobra.Command, _ []string) {
 	logger := logging.NewLogger(c)
 
 	readCampaignActivity := logger.StartActivity("Reading campaign data")
-	dir, err := campaign.OpenCampaign()
+	defaultOptions := campaign.NewCampaignOptions()
+	defaultOptions.RepoFilename = repoFile
+	dir, err := campaign.OpenCampaign(defaultOptions)
 	if err != nil {
 		readCampaignActivity.EndWithFailure(err)
 		return

--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -16,17 +16,20 @@
 package foreach
 
 import (
+	"os"
+	"path"
+	"strings"
+
 	"github.com/skyscanner/turbolift/internal/campaign"
 	"github.com/skyscanner/turbolift/internal/colors"
 	"github.com/skyscanner/turbolift/internal/executor"
 	"github.com/skyscanner/turbolift/internal/logging"
 	"github.com/spf13/cobra"
-	"os"
-	"path"
-	"strings"
 )
 
 var exec executor.Executor = executor.NewRealExecutor()
+
+var repoFile string
 
 func NewForeachCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,6 +40,8 @@ func NewForeachCmd() *cobra.Command {
 		DisableFlagParsing: true,
 	}
 
+	cmd.Flags().StringVar(&repoFile, "repos", "repos.txt", "A file containing a list of repositories to clone.")
+
 	return cmd
 }
 
@@ -44,7 +49,9 @@ func run(c *cobra.Command, args []string) {
 	logger := logging.NewLogger(c)
 
 	readCampaignActivity := logger.StartActivity("Reading campaign data")
-	dir, err := campaign.OpenCampaign()
+	defaultOptions := campaign.NewCampaignOptions()
+	defaultOptions.RepoFilename = repoFile
+	dir, err := campaign.OpenCampaign(defaultOptions)
 	if err != nil {
 		readCampaignActivity.EndWithFailure(err)
 		return

--- a/internal/campaign/campaign.go
+++ b/internal/campaign/campaign.go
@@ -38,11 +38,19 @@ type Campaign struct {
 	PrBody  string
 }
 
-func OpenCampaign() (*Campaign, error) {
+type CampainOptions struct {
+	RepoFilename string
+}
+
+func NewCampaignOptions() *CampainOptions {
+	return &CampainOptions{RepoFilename: "repos.txt"}
+}
+
+func OpenCampaign(options *CampainOptions) (*Campaign, error) {
 	dir, _ := os.Getwd()
 	dirBasename := filepath.Base(dir)
 
-	repos, err := readReposTxtFile()
+	repos, err := readReposTxtFile(options.RepoFilename)
 	if err != nil {
 		return nil, err
 	}
@@ -60,10 +68,13 @@ func OpenCampaign() (*Campaign, error) {
 	}, nil
 }
 
-func readReposTxtFile() ([]Repo, error) {
-	file, err := os.Open("repos.txt")
+func readReposTxtFile(filename string) ([]Repo, error) {
+	if filename == "" {
+		return nil, errors.New("no repos filename to open")
+	}
+	file, err := os.Open(filename)
 	if err != nil {
-		return nil, errors.New("unable to open repos.txt file")
+		return nil, fmt.Errorf("unable to open %s file", filename)
 	}
 	defer func() {
 		closeErr := file.Close()
@@ -87,28 +98,29 @@ func readReposTxtFile() ([]Repo, error) {
 			numParts := len(splitLine)
 
 			var repo Repo
-			if numParts == 2 {
+			switch numParts {
+			case 2:
 				repo = Repo{
 					OrgName:      splitLine[0],
 					RepoName:     splitLine[1],
 					FullRepoName: line,
 				}
-			} else if numParts == 3 {
+			case 3:
 				repo = Repo{
 					Host:         splitLine[0],
 					OrgName:      splitLine[1],
 					RepoName:     splitLine[2],
 					FullRepoName: line,
 				}
-			} else {
-				return nil, fmt.Errorf("unable to parse entry in repos.txt file: %s", line)
+			default:
+				return nil, fmt.Errorf("unable to parse entry in %s file: %s", filename, line)
 			}
 			repos = append(repos, repo)
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("unable to open repos.txt file: %w", err)
+		return nil, fmt.Errorf("unable to open %s file: %w", filename, err)
 	}
 
 	return repos, nil

--- a/internal/campaign/campaign_test.go
+++ b/internal/campaign/campaign_test.go
@@ -16,15 +16,17 @@
 package campaign
 
 import (
+	"testing"
+
 	"github.com/skyscanner/turbolift/internal/testsupport"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestItReadsSimpleRepoNamesFromReposFile(t *testing.T) {
 	testsupport.PrepareTempCampaign(false, "org/repo1", "org/repo2")
 
-	campaign, err := OpenCampaign()
+	defaultOptions := NewCampaignOptions()
+	campaign, err := OpenCampaign(defaultOptions)
 	assert.NoError(t, err)
 
 	assert.Equal(t, testsupport.Pwd(), campaign.Name)
@@ -49,7 +51,8 @@ func TestItReadsSimpleRepoNamesFromReposFile(t *testing.T) {
 func TestItReadsRepoNamesWithOtherHostsFromReposFile(t *testing.T) {
 	testsupport.PrepareTempCampaign(false, "org/repo1", "mygitserver.com/org/repo2")
 
-	campaign, err := OpenCampaign()
+	defaultOptions := NewCampaignOptions()
+	campaign, err := OpenCampaign(defaultOptions)
 	assert.NoError(t, err)
 
 	assert.Equal(t, testsupport.Pwd(), campaign.Name)
@@ -74,7 +77,8 @@ func TestItReadsRepoNamesWithOtherHostsFromReposFile(t *testing.T) {
 func TestItIgnoresCommentedLines(t *testing.T) {
 	testsupport.PrepareTempCampaign(false, "org/repo1", "#org/repo2")
 
-	campaign, err := OpenCampaign()
+	defaultOptions := NewCampaignOptions()
+	campaign, err := OpenCampaign(defaultOptions)
 	assert.NoError(t, err)
 
 	assert.Equal(t, testsupport.Pwd(), campaign.Name)
@@ -93,7 +97,8 @@ func TestItIgnoresCommentedLines(t *testing.T) {
 func TestItIgnoresEmptyLines(t *testing.T) {
 	testsupport.PrepareTempCampaign(false, "org/repo1", "")
 
-	campaign, err := OpenCampaign()
+	defaultOptions := NewCampaignOptions()
+	campaign, err := OpenCampaign(defaultOptions)
 	assert.NoError(t, err)
 
 	assert.Equal(t, testsupport.Pwd(), campaign.Name)
@@ -112,7 +117,8 @@ func TestItIgnoresEmptyLines(t *testing.T) {
 func TestItIgnoresEmptyAndCommentedLines(t *testing.T) {
 	testsupport.PrepareTempCampaign(false, "#Comment", "org/repo1", "")
 
-	campaign, err := OpenCampaign()
+	defaultOptions := NewCampaignOptions()
+	campaign, err := OpenCampaign(defaultOptions)
 	assert.NoError(t, err)
 
 	assert.Equal(t, testsupport.Pwd(), campaign.Name)
@@ -131,7 +137,8 @@ func TestItIgnoresEmptyAndCommentedLines(t *testing.T) {
 func TestItIgnoresDuplicatedLines(t *testing.T) {
 	testsupport.PrepareTempCampaign(false, "org/repo1", "org/repo1")
 
-	campaign, err := OpenCampaign()
+	defaultOptions := NewCampaignOptions()
+	campaign, err := OpenCampaign(defaultOptions)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []Repo{
@@ -147,7 +154,8 @@ func TestItIgnoresDuplicatedLines(t *testing.T) {
 func TestItIgnoresDuplicatedNonSequentialLines(t *testing.T) {
 	testsupport.PrepareTempCampaign(false, "org/repo1", "org/repo2", "org/repo1")
 
-	campaign, err := OpenCampaign()
+	defaultOptions := NewCampaignOptions()
+	campaign, err := OpenCampaign(defaultOptions)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []Repo{
@@ -164,4 +172,52 @@ func TestItIgnoresDuplicatedNonSequentialLines(t *testing.T) {
 			FullRepoName: "org/repo2",
 		},
 	}, campaign.Repos)
+}
+
+func TestItShouldAcceptADifferentRepoFileSuccess(t *testing.T) {
+	testsupport.PrepareTempCampaign(false)
+
+	testsupport.CreateAnotherRepoFile("newrepos.txt", "org/repo1", "org/repo2", "org/repo3")
+	options := NewCampaignOptions()
+	options.RepoFilename = "newrepos.txt"
+	campaign, err := OpenCampaign(options)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []Repo{
+		{
+			Host:         "",
+			OrgName:      "org",
+			RepoName:     "repo1",
+			FullRepoName: "org/repo1",
+		},
+		{
+			Host:         "",
+			OrgName:      "org",
+			RepoName:     "repo2",
+			FullRepoName: "org/repo2",
+		},
+		{
+			Host:         "",
+			OrgName:      "org",
+			RepoName:     "repo3",
+			FullRepoName: "org/repo3",
+		},
+	}, campaign.Repos)
+}
+
+func TestItShouldAcceptADifferentRepoFileNotExist(t *testing.T) {
+	testsupport.PrepareTempCampaign(false)
+
+	options := NewCampaignOptions()
+	options.RepoFilename = "newrepos.txt"
+	_, err := OpenCampaign(options)
+	assert.Error(t, err)
+}
+
+func TestItShouldErrorWhenRepoFileIsNil(t *testing.T) {
+	testsupport.PrepareTempCampaign(false)
+
+	options := &CampainOptions{}
+	_, err := OpenCampaign(options)
+	assert.Error(t, err)
 }

--- a/internal/testsupport/testsupport.go
+++ b/internal/testsupport/testsupport.go
@@ -31,7 +31,6 @@ func Pwd() string {
 func CreateAndEnterTempDirectory() {
 	tempDir, _ := ioutil.TempDir("", "turbolift-test-*")
 	err := os.Chdir(tempDir)
-
 	if err != nil {
 		panic(err)
 	}
@@ -58,6 +57,14 @@ func PrepareTempCampaign(createDirs bool, repos ...string) {
 
 	dummyPrDescription := "# PR title\nPR body"
 	err = ioutil.WriteFile("README.md", []byte(dummyPrDescription), os.ModePerm|0644)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func CreateAnotherRepoFile(filename string, repos ...string) {
+	delimitedList := strings.Join(repos, "\n")
+	err := ioutil.WriteFile(filename, []byte(delimitedList), os.ModePerm|0644)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes #74

Adds a new flag for all commands `--repos=<filename>`, which gives the
ability to select a different file from the default `repos.txt` one.
