### PR TITLE
Add schedule to CodeQL Scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,8 @@
 name: CodeQL
 on:
   pull_request:
+  schedule:
+    - cron: '09 09 * * 1'
 
 jobs:
   codeql:


### PR DESCRIPTION
Running CodeQL on regularly whether there are changes or not is beneficial. If new queries or vulnerabilities are found and the project is inactive at the time this run is used to make sure that they are flagged.

I chose a random day and time to run weekly. Cron is every Monday at 09:09 UTC