### PR TITLE
Fixing foreach documentation

### DIFF
--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -19,16 +19,19 @@ import (
 	"os"
 	"path"
 
+	"github.com/spf13/cobra"
+
 	"github.com/skyscanner/turbolift/internal/campaign"
 	"github.com/skyscanner/turbolift/internal/colors"
 	"github.com/skyscanner/turbolift/internal/git"
 	"github.com/skyscanner/turbolift/internal/github"
 	"github.com/skyscanner/turbolift/internal/logging"
-	"github.com/spf13/cobra"
 )
 
-var gh github.GitHub = github.NewRealGitHub()
-var g git.Git = git.NewRealGit()
+var (
+	gh github.GitHub = github.NewRealGitHub()
+	g  git.Git       = git.NewRealGit()
+)
 
 var nofork bool
 
@@ -66,7 +69,7 @@ func run(c *cobra.Command, _ []string) {
 			cloneActivity = logger.StartActivity("Forking and cloning %s into %s/%s", repo.FullRepoName, orgDirPath, repo.RepoName)
 		}
 
-		err := os.MkdirAll(orgDirPath, os.ModeDir|0755)
+		err := os.MkdirAll(orgDirPath, os.ModeDir|0o755)
 		if err != nil {
 			cloneActivity.EndWithFailuref("Unable to create org directory: %s", err)
 			errorCount++
@@ -115,7 +118,7 @@ func run(c *cobra.Command, _ []string) {
 	}
 	logger.Println("To continue:")
 	logger.Println("\t1. Make your changes in the cloned repositories within the", colors.Cyan("work"), "directory")
-	logger.Println("\t2. Add new files across all repos using", colors.Cyan(`turbolift foreach -- git add -A`))
+	logger.Println("\t2. Add new files across all repos using", colors.Cyan(`turbolift foreach git add -A`))
 	logger.Println("\t3. Commit changes across all repos using", colors.Cyan(`turbolift commit --message "Your commit message"`))
 	logger.Println("\t4. Change the PR title and description in the", colors.Cyan(`README.md`), "of a campaign")
 }

--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -16,21 +16,22 @@
 package foreach
 
 import (
+	"os"
+	"path"
+	"strings"
+
 	"github.com/skyscanner/turbolift/internal/campaign"
 	"github.com/skyscanner/turbolift/internal/colors"
 	"github.com/skyscanner/turbolift/internal/executor"
 	"github.com/skyscanner/turbolift/internal/logging"
 	"github.com/spf13/cobra"
-	"os"
-	"path"
-	"strings"
 )
 
 var exec executor.Executor = executor.NewRealExecutor()
 
 func NewForeachCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                "foreach -- SHELL_COMMAND",
+		Use:                "foreach SHELL_COMMAND",
 		Short:              "Run a shell command against each working copy",
 		Run:                run,
 		Args:               cobra.MinimumNArgs(1),


### PR DESCRIPTION
the `--` were needed for any command including parameters prior to #51.
After #51, the `--` are no longer needed a cobra isn't trying to parse
the full command. It's also failing the run now if the `--` are
included since they are interpreted as part of the command.

This commit fixes the documentation associated with `foreach`.

I've not found any other reference of the `--` anywhere else in the repo.
