### PR TITLE
Add Homebrew tap publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,4 +21,15 @@ archives:
       amd64: x86_64
 checksum:
   name_template: 'checksums.txt'
+brews:
+  - name: turbolift
+    description: A simple tool to help apply changes across many GitHub repositories simultaneously
+    homepage: https://github.com/Skyscanner/turbolift
+    license: Apache 2.0
+    tap:
+      owner: Skyscanner
+      name: homebrew-tools
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    dependencies:
+      - name: gh
 


### PR DESCRIPTION
Fixes #43

Will cause each released version to have a formula pushed to Skyscanner/homebrew-tools