### PR TITLE
Help flag in Foreach returns usage

### DIFF
--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -47,7 +47,7 @@ MAIN:
 			helpFlag = true
 		default:
 			// we've parsed everything that could be parsed; this is now the command
-			if len(args) > 1 {
+			if len(args[i:]) > 0 {
 				strippedArgs = args[i:]
 			}
 			break MAIN

--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -47,9 +47,7 @@ MAIN:
 			helpFlag = true
 		default:
 			// we've parsed everything that could be parsed; this is now the command
-			if len(args[i:]) > 0 {
-				strippedArgs = args[i:]
-			}
+			strippedArgs = append(strippedArgs, args[i:]...)
 			break MAIN
 		}
 	}

--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -30,23 +30,31 @@ import (
 
 var exec executor.Executor = executor.NewRealExecutor()
 
-var repoFile string = "repos.txt"
+var (
+	repoFile string = "repos.txt"
+	helpFlag bool   = false
+)
 
-func parseForeachArgs(args []string) (strippedArgs []string) {
+func parseForeachArgs(args []string) []string {
+	strippedArgs := make([]string, 0)
 MAIN:
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
 		case "--repos":
 			repoFile = args[i+1]
 			i = i + 1
+		case "--help":
+			helpFlag = true
 		default:
 			// we've parsed everything that could be parsed; this is now the command
-			strippedArgs = args[i:]
+			if len(args) > 1 {
+				strippedArgs = args[i:]
+			}
 			break MAIN
 		}
 	}
 
-	return
+	return strippedArgs
 }
 
 func NewForeachCmd() *cobra.Command {
@@ -74,6 +82,12 @@ func run(c *cobra.Command, args []string) {
 		Assumption is the foreach arguments will be parsed before the command and its arguments.
 	*/
 	args = parseForeachArgs(args)
+
+	// check if the help flag was toggled
+	if helpFlag {
+		_ = c.Usage()
+		return
+	}
 
 	readCampaignActivity := logger.StartActivity("Reading campaign data (%s)", repoFile)
 	options := campaign.NewCampaignOptions()

--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -57,11 +57,12 @@ MAIN:
 
 func NewForeachCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                "foreach SHELL_COMMAND",
-		Short:              "Run a shell command against each working copy",
-		Run:                run,
-		Args:               cobra.MinimumNArgs(1),
-		DisableFlagParsing: true,
+		Use:                   "foreach [flags] SHELL_COMMAND",
+		Short:                 "Run a shell command against each working copy",
+		Run:                   run,
+		Args:                  cobra.MinimumNArgs(1),
+		DisableFlagsInUseLine: true,
+		DisableFlagParsing:    true,
 	}
 
 	// this flag will not be parsed (DisabledFlagParsing is on) but is here for the help context and auto complete

--- a/cmd/foreach/foreach_test.go
+++ b/cmd/foreach/foreach_test.go
@@ -32,42 +32,70 @@ func TestParseForEachArgs(t *testing.T) {
 		Args                 []string
 		ExpectedCommand      []string
 		ExpectedRepoFileName string
+		ExpectedHelpFlag     bool
 	}{
 		{
 			Name:                 "simple command",
 			Args:                 []string{"ls", "-l"},
 			ExpectedCommand:      []string{"ls", "-l"},
 			ExpectedRepoFileName: "repos.txt",
+			ExpectedHelpFlag:     false,
 		},
 		{
 			Name:                 "advanced command",
 			Args:                 []string{"sed", "-e", "'s/foo/bar/'", "-e", "'s/bar/baz/'"},
 			ExpectedCommand:      []string{"sed", "-e", "'s/foo/bar/'", "-e", "'s/bar/baz/'"},
 			ExpectedRepoFileName: "repos.txt",
+			ExpectedHelpFlag:     false,
 		},
 		{
 			Name:                 "simple command with repo flag",
 			Args:                 []string{"--repos", "test.txt", "ls", "-l"},
 			ExpectedCommand:      []string{"ls", "-l"},
 			ExpectedRepoFileName: "test.txt",
+			ExpectedHelpFlag:     false,
 		},
 		{
 			Name:                 "advanced command with repos flag",
 			Args:                 []string{"--repos", "test2.txt", "sed", "-e", "'s/foo/bar/'", "-e", "'s/bar/baz/'"},
 			ExpectedCommand:      []string{"sed", "-e", "'s/foo/bar/'", "-e", "'s/bar/baz/'"},
 			ExpectedRepoFileName: "test2.txt",
+			ExpectedHelpFlag:     false,
 		},
 		{
 			Name:                 "repos flag should only be caught when at the beginning",
 			Args:                 []string{"ls", "-l", "--repos", "random.txt"},
 			ExpectedCommand:      []string{"ls", "-l", "--repos", "random.txt"},
 			ExpectedRepoFileName: "repos.txt",
+			ExpectedHelpFlag:     false,
 		},
 		{
 			Name:                 "random flag is not caught",
 			Args:                 []string{"--random", "arg", "ls", "-l"},
 			ExpectedCommand:      []string{"--random", "arg", "ls", "-l"},
 			ExpectedRepoFileName: "repos.txt",
+			ExpectedHelpFlag:     false,
+		},
+		{
+			Name:                 "Help flag is triggered",
+			Args:                 []string{"--help"},
+			ExpectedCommand:      []string{},
+			ExpectedRepoFileName: "repos.txt",
+			ExpectedHelpFlag:     true,
+		},
+		{
+			Name:                 "Help flag is triggered after the repo one",
+			Args:                 []string{"--repos", "example.txt", "--help", "thecommand"},
+			ExpectedCommand:      []string{"thecommand"},
+			ExpectedRepoFileName: "example.txt",
+			ExpectedHelpFlag:     true,
+		},
+		{
+			Name:                 "Help flag is triggered before the repo one",
+			Args:                 []string{"--help", "--repos", "example.txt", "newcommand", "anotherarg"},
+			ExpectedCommand:      []string{"newcommand", "anotherarg"},
+			ExpectedRepoFileName: "example.txt",
+			ExpectedHelpFlag:     true,
 		},
 	}
 
@@ -77,9 +105,11 @@ func TestParseForEachArgs(t *testing.T) {
 			t.Log(actual)
 			assert.EqualValues(t, tc.ExpectedCommand, actual)
 			assert.Equal(t, repoFile, tc.ExpectedRepoFileName)
+			assert.Equal(t, helpFlag, tc.ExpectedHelpFlag)
 
 			// Cleanup to default repo file name
 			repoFile = "repos.txt"
+			helpFlag = false
 		})
 	}
 }
@@ -146,6 +176,25 @@ func TestItContinuesOnAndRecordsFailures(t *testing.T) {
 		{"work/org/repo1", userShell(), "-c", "some command"},
 		{"work/org/repo2", userShell(), "-c", "some command"},
 	})
+}
+
+func TestHelpFlagReturnsUsage(t *testing.T) {
+	fakeExecutor := executor.NewAlwaysSucceedsFakeExecutor()
+	exec = fakeExecutor
+
+	testsupport.PrepareTempCampaign(true, "org/repo1", "org/repo2")
+
+	out, err := runCommand("--help", "command1")
+	t.Log(out)
+	assert.NoError(t, err)
+	// should return usage
+	assert.Contains(t, out, "Usage:")
+	assert.Contains(t, out, "foreach SHELL_COMMAND [flags]")
+	assert.Contains(t, out, "Flags:")
+	assert.Contains(t, out, "help for foreach")
+
+	// nothing should have been called
+	fakeExecutor.AssertCalledWith(t, [][]string{})
 }
 
 func userShell() string {

--- a/cmd/foreach/foreach_test.go
+++ b/cmd/foreach/foreach_test.go
@@ -97,6 +97,13 @@ func TestParseForEachArgs(t *testing.T) {
 			ExpectedRepoFileName: "example.txt",
 			ExpectedHelpFlag:     true,
 		},
+		{
+			Name:                 "Help flag is not triggered from a subsequent command",
+			Args:                 []string{"command", "--help"},
+			ExpectedCommand:      []string{"command", "--help"},
+			ExpectedRepoFileName: "repos.txt",
+			ExpectedHelpFlag:     false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/foreach/foreach_test.go
+++ b/cmd/foreach/foreach_test.go
@@ -196,7 +196,7 @@ func TestHelpFlagReturnsUsage(t *testing.T) {
 	assert.NoError(t, err)
 	// should return usage
 	assert.Contains(t, out, "Usage:")
-	assert.Contains(t, out, "foreach SHELL_COMMAND [flags]")
+	assert.Contains(t, out, "foreach [flags] SHELL_COMMAND")
 	assert.Contains(t, out, "Flags:")
 	assert.Contains(t, out, "help for foreach")
 


### PR DESCRIPTION
Fixes #96.

This PR fixes the current bug in the ForEach command where the help flag
is not parsed properly and doesn't return the usage.
