### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Some of the GitHub action versions are old, and are generating deprecation warnings (recent examples: a [CodeQL deprecation warning](https://github.com/Skyscanner/turbolift/actions/runs/6144390808), and a [checkout and setup-go warning](https://github.com/Skyscanner/turbolift/actions/runs/6085364824)).

Rather than address these in a one-off commit, this PR introduces a Dependabot config to regularly update the GitHub actions as new versions are released.

If this merges, you can expect Dependabot to immediately submit multiple PRs to update all of the action versions to their latest versions.

Thanks for your work on Turbolift!