### PR TITLE
Clone repositories with a depth of 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,14 @@ You may wish to skip the fork and work on the upstream repository branch directl
 > omit the `--no-fork` flag and let all the repositories be forked.
 > For now, it's an all-or-nothing scenario.
 
-Repositories are cloned with the git flag `--depth=1`.
-If you need the full commit history and tags, you can run the following command
-after running `turbolift clone`:
-
-```shell
-turbolift foreach git fetch --unshallow --tags
-```
+> **Note**
+> Repositories are cloned with the git flag `--depth=1`.
+> If you need the full commit history and tags, you can run the following command
+> after running `turbolift clone`:
+> 
+> ```shell
+> turbolift foreach git fetch --unshallow --tags
+> ```
 
 ### Making changes
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You may wish to skip the fork and work on the upstream repository branch directl
 > omit the `--no-fork` flag and let all the repositories be forked.
 > For now, it's an all-or-nothing scenario.
 
-> **Note**
+> [!NOTE]
 > Repositories are cloned with the git flag `--depth=1`.
 > If you need the full commit history and tags, you can run the following command
 > after running `turbolift clone`:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,17 @@ turbolift foreach --repos repoFile2.txt sed 's/pattern2/replacement2/g'
 This creates a fork and clones all repositories listed in the `repos.txt` file into the `work` directory.
 You may wish to skip the fork and work on the upstream repository branch directly with the flag `--no-fork`.
 
-> NTLD: if one of the repositories in the list requires a fork to create a PR, omit the `--no-fork` flag and let all the repositories be forked. For now it's a all-or-nothing scenario.
+> NTLD: if one of the repositories in the list requires a fork to create a PR,
+> omit the `--no-fork` flag and let all the repositories be forked.
+> For now, it's an all-or-nothing scenario.
+
+Repositories are cloned with the git flag `--depth=1`.
+If you need the full commit history and tags, you can run the following command
+after running `turbolift clone`:
+
+```shell
+turbolift foreach git fetch --unshallow --tags
+```
 
 ### Making changes
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -71,11 +71,11 @@ func (r *RealGitHub) CreatePullRequest(output io.Writer, workingDir string, pr P
 }
 
 func (r *RealGitHub) ForkAndClone(output io.Writer, workingDir string, fullRepoName string) error {
-	return execInstance.Execute(output, workingDir, "gh", "repo", "fork", "--clone=true", fullRepoName)
+	return execInstance.Execute(output, workingDir, "gh", "repo", "fork", "--clone=true", fullRepoName, "--", "--depth=1")
 }
 
 func (r *RealGitHub) Clone(output io.Writer, workingDir string, fullRepoName string) error {
-	return execInstance.Execute(output, workingDir, "gh", "repo", "clone", fullRepoName)
+	return execInstance.Execute(output, workingDir, "gh", "repo", "clone", fullRepoName, "--", "--depth=1")
 }
 
 func (r *RealGitHub) ClosePullRequest(output io.Writer, workingDir string, branchName string) error {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -31,7 +31,7 @@ func TestItReturnsErrorOnFailedFork(t *testing.T) {
 	assert.Error(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1"},
+		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1", "--", "--depth=1"},
 	})
 }
 
@@ -43,7 +43,7 @@ func TestItReturnsNilErrorOnSuccessfulFork(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1"},
+		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1", "--", "--depth=1"},
 	})
 }
 
@@ -55,7 +55,7 @@ func TestItReturnsErrorOnFailedClone(t *testing.T) {
 	assert.Error(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "clone", "org/repo1"},
+		{"work/org", "gh", "repo", "clone", "org/repo1", "--", "--depth=1"},
 	})
 }
 
@@ -67,7 +67,7 @@ func TestItReturnsNilErrorOnSuccessfulClone(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "clone", "org/repo1"},
+		{"work/org", "gh", "repo", "clone", "org/repo1", "--", "--depth=1"},
 	})
 }
 


### PR DESCRIPTION
This PR attempts to introduce `--depth=1` as a consistent `git clone` parameter, and documents how to fetch the rich git history if needed.

Please let me know if additional changes are needed, and thanks for your work on turbolift!

----

Note that I wasn't able to run `make lint` due to this error:

```text
$ make test
--- lint all the things
WARN [runner] Can't run linter goanalysis_metalinter: buildir: failed to load package goarch:
could not load export data: cannot import "internal/goarch" (unknown bexport format version -1
("u\x01\x00\x00...
```

Go developers may understand this, but I was lost. I used the pre-commit config I introduced in #103 to at least lint the code, and it passed. I was also able to run `make test` (though this error printed first) and `make build`.

I recommend relying on pre-commit for linting and fixing, due to its ability to standardize environments.

I also recommend introducing a changelog to the repo.

Closes #89