### PR TITLE
Fixes the release with goreleaser fixed version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
-          args: release --rm-dist
+          version: v1.18.2
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
# Why this change?

Goreleaser has deprecated [Replacements](https://github.com/Skyscanner/turbolift/blob/9f28424daf82663b91716b6888c12cfb6a04ca0e/.goreleaser.yml#L16-L21) since this [commit](https://github.com/goreleaser/goreleaser/pull/3589/files#diff-5563ff2aab3eb7eae7bd8557cd2c086d8373263762684283485b2f0a00a0f52a).
The github action for goreleaser uses the latest goreleaser version instead of a fixed version.

We need to address the replacements in a future commit, for now we are forcing an older version of goreleaser.
The version of goreleaser that includes the deprecation of `replacements` is [v1.19.0](https://github.com/goreleaser/goreleaser/releases/tag/v1.19.0).
We are rolling back now to [v1.18.2](https://github.com/goreleaser/goreleaser/releases/tag/v1.18.2).
