### PR TITLE
Fix goreleaser and deprecate replacements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
-          version: v1.18.2
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,9 +13,9 @@ builds:
     ldflags:
       - -s -w -X github.com/skyscanner/turbolift/cmd.version={{.Version}} -X github.com/skyscanner/turbolift/cmd.commit={{.Commit}} -X github.com/skyscanner/turbolift/cmd.date={{.Date}}
 archives:
-  - id: foo
-    name_template: >-
+  - name_template: >-
       {{- .ProjectName }}_
+      {{- .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,14 +13,15 @@ builds:
     ldflags:
       - -s -w -X github.com/skyscanner/turbolift/cmd.version={{.Version}} -X github.com/skyscanner/turbolift/cmd.commit={{.Commit}} -X github.com/skyscanner/turbolift/cmd.date={{.Date}}
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 brews:
   - name: turbolift
     description: Simple tool to help apply changes across many GitHub repositories simultaneously
@@ -32,4 +33,3 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     dependencies:
       - name: gh
-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,8 @@ builds:
     ldflags:
       - -s -w -X github.com/skyscanner/turbolift/cmd.version={{.Version}} -X github.com/skyscanner/turbolift/cmd.commit={{.Commit}} -X github.com/skyscanner/turbolift/cmd.date={{.Date}}
 archives:
-  - name_template: >-
+  - id: foo
+    name_template: >-
       {{- .ProjectName }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
@@ -27,7 +28,7 @@ brews:
     description: Simple tool to help apply changes across many GitHub repositories simultaneously
     homepage: https://github.com/Skyscanner/turbolift
     license: Apache-2.0
-    tap:
+    repository:
       owner: Skyscanner
       name: homebrew-tools
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
Since v1.19.0, goreleaser is not supporting replacements in its
configuration, rather it points you to using a template.

This change reverses the workaround from #110 and introduces
a forward-fix for this.

We still have an issue with goreleaser action using `latest` but it's by
design on their behalf.

At the same time, this PR changes also `brews.taps` as it's also marked as `deprecated` on the same version.

Documentation:
- https://goreleaser.com/deprecations/?h=replacements
- https://goreleaser.com/deprecations/#brewstap
