### PR TITLE
Refactor Github Mock Handler

### DIFF
--- a/cmd/prstatus/prstatus_test.go
+++ b/cmd/prstatus/prstatus_test.go
@@ -18,7 +18,6 @@ package prstatus
 import (
 	"bytes"
 	"errors"
-	"io"
 	"os"
 	"testing"
 
@@ -160,7 +159,7 @@ func prepareFakeResponses() {
 			},
 		},
 	}
-	fakeGitHub := github.NewFakeGitHub(nil, func(output io.Writer, workingDir string) (interface{}, error) {
+	fakeGitHub := github.NewFakeGitHub(nil, func(workingDir string) (interface{}, error) {
 		if workingDir == "work/org/repoWithError" {
 			return nil, errors.New("Synthetic error")
 		} else {

--- a/internal/github/fake_github.go
+++ b/internal/github/fake_github.go
@@ -24,48 +24,51 @@ import (
 )
 
 type FakeGitHub struct {
-	handler          func(output io.Writer, command Command, workingDir string, fullRepoName string) (bool, error)
-	returningHandler func(output io.Writer, workingDir string) (interface{}, error)
+	handler          func(command Command, args []string) (bool, error)
+	returningHandler func() (interface{}, error)
 	calls            [][]string
 }
 
-func (f *FakeGitHub) CreatePullRequest(output io.Writer, workingDir string, metadata PullRequest) (didCreate bool, err error) {
-	f.calls = append(f.calls, []string{workingDir, metadata.Title})
-	return f.handler(output, CreatePullRequest, workingDir, "")
+func (f *FakeGitHub) CreatePullRequest(_ io.Writer, workingDir string, metadata PullRequest) (didCreate bool, err error) {
+	args := []string{workingDir, metadata.Title}
+	f.calls = append(f.calls, args)
+	return f.handler(CreatePullRequest, args)
 }
 
-func (f *FakeGitHub) ForkAndClone(output io.Writer, workingDir string, fullRepoName string) error {
-	f.calls = append(f.calls, []string{workingDir, fullRepoName})
-	_, err := f.handler(output, ForkAndClone, workingDir, fullRepoName)
+func (f *FakeGitHub) ForkAndClone(_ io.Writer, workingDir string, fullRepoName string) error {
+	args := []string{workingDir, fullRepoName}
+	f.calls = append(f.calls, args)
+	_, err := f.handler(ForkAndClone, args)
 	return err
 }
 
-func (f *FakeGitHub) Clone(output io.Writer, workingDir string, fullRepoName string) error {
-	f.calls = append(f.calls, []string{workingDir, fullRepoName})
-	_, err := f.handler(output, Clone, workingDir, fullRepoName)
+func (f *FakeGitHub) Clone(_ io.Writer, workingDir string, fullRepoName string) error {
+	args := []string{workingDir, fullRepoName}
+	f.calls = append(f.calls, args)
+	_, err := f.handler(Clone, args)
 	return err
 }
 
-func (f *FakeGitHub) ClosePullRequest(output io.Writer, workingDir string, branchName string) error {
-	// TODO: handle this differently; branchName here is replacing fullRepoName
-	// This is OK for now because fullRepoName is used nowhere in the github mocks
-	f.calls = append(f.calls, []string{workingDir, branchName})
-	_, err := f.handler(output, ClosePullRequest, workingDir, branchName)
+func (f *FakeGitHub) ClosePullRequest(_ io.Writer, workingDir string, branchName string) error {
+	args := []string{workingDir, branchName}
+	f.calls = append(f.calls, args)
+	_, err := f.handler(ClosePullRequest, args)
 	return err
 }
 
-func (f *FakeGitHub) GetPR(output io.Writer, workingDir string, _ string) (*PrStatus, error) {
+func (f *FakeGitHub) GetPR(_ io.Writer, workingDir string, _ string) (*PrStatus, error) {
 	f.calls = append(f.calls, []string{workingDir})
-	result, err := f.returningHandler(output, workingDir)
+	result, err := f.returningHandler()
 	if result == nil {
 		return nil, err
 	}
 	return result.(*PrStatus), err
 }
 
-func (f *FakeGitHub) GetDefaultBranchName(output io.Writer, workingDir string, fullRepoName string) (string, error) {
-	f.calls = append(f.calls, []string{workingDir, fullRepoName})
-	_, err := f.handler(output, GetDefaultBranchName, workingDir, fullRepoName)
+func (f *FakeGitHub) GetDefaultBranchName(_ io.Writer, workingDir string, fullRepoName string) (string, error) {
+	args := []string{workingDir, fullRepoName}
+	f.calls = append(f.calls, args)
+	_, err := f.handler(GetDefaultBranchName, args)
 	return "main", err
 }
 
@@ -73,7 +76,7 @@ func (f *FakeGitHub) AssertCalledWith(t *testing.T, expected [][]string) {
 	assert.Equal(t, expected, f.calls)
 }
 
-func NewFakeGitHub(h func(output io.Writer, command Command, workingDir string, fullRepoName string) (bool, error), r func(output io.Writer, workingDir string) (interface{}, error)) *FakeGitHub {
+func NewFakeGitHub(h func(command Command, args []string) (bool, error), r func() (interface{}, error)) *FakeGitHub {
 	return &FakeGitHub{
 		handler:          h,
 		returningHandler: r,
@@ -82,44 +85,45 @@ func NewFakeGitHub(h func(output io.Writer, command Command, workingDir string, 
 }
 
 func NewAlwaysSucceedsFakeGitHub() *FakeGitHub {
-	return NewFakeGitHub(func(output io.Writer, command Command, workingDir string, fullRepoName string) (bool, error) {
+	return NewFakeGitHub(func(command Command, args []string) (bool, error) {
 		return true, nil
-	}, func(output io.Writer, workingDir string) (interface{}, error) {
+	}, func() (interface{}, error) {
 		return PrStatus{}, nil
 	})
 }
 
 func NewAlwaysFailsFakeGitHub() *FakeGitHub {
-	return NewFakeGitHub(func(output io.Writer, command Command, workingDir string, fullRepoName string) (bool, error) {
+	return NewFakeGitHub(func(command Command, args []string) (bool, error) {
 		return false, errors.New("synthetic error")
-	}, func(output io.Writer, workingDir string) (interface{}, error) {
+	}, func() (interface{}, error) {
 		return nil, errors.New("synthetic error")
 	})
 }
 
 func NewAlwaysThrowNoPRFound() *FakeGitHub {
-	return NewFakeGitHub(func(output io.Writer, command Command, workingDir string, branchName string) (bool, error) {
+	return NewFakeGitHub(func(command Command, args []string) (bool, error) {
+		workingDir, branchName := args[0], args[1]
 		return false, &NoPRFoundError{Path: workingDir, BranchName: branchName}
-	}, func(output io.Writer, workingDir string) (interface{}, error) {
+	}, func() (interface{}, error) {
 		panic("should not be invoked")
 	})
 }
 
 func NewAlwaysReturnsFalseFakeGitHub() *FakeGitHub {
-	return NewFakeGitHub(func(output io.Writer, command Command, workingDir string, fullRepoName string) (bool, error) {
+	return NewFakeGitHub(func(command Command, args []string) (bool, error) {
 		return false, nil
-	}, func(output io.Writer, workingDir string) (interface{}, error) {
+	}, func() (interface{}, error) {
 		return PrStatus{}, nil
 	})
 }
 
 func NewAlwaysFailsOnGetDefaultBranchFakeGitHub() *FakeGitHub {
-	return NewFakeGitHub(func(output io.Writer, command Command, workingDir string, fullRepoName string) (bool, error) {
+	return NewFakeGitHub(func(command Command, args []string) (bool, error) {
 		if command == GetDefaultBranchName {
 			return false, errors.New("synthetic error")
 		}
 		return true, nil
-	}, func(output io.Writer, workingDir string) (interface{}, error) {
+	}, func() (interface{}, error) {
 		return PrStatus{}, nil
 	})
 }
@@ -132,4 +136,5 @@ const (
 	CreatePullRequest
 	ClosePullRequest
 	GetDefaultBranchName
+	GetPR
 )

--- a/internal/github/fake_github.go
+++ b/internal/github/fake_github.go
@@ -136,5 +136,4 @@ const (
 	CreatePullRequest
 	ClosePullRequest
 	GetDefaultBranchName
-	GetPR
 )


### PR DESCRIPTION
As part of adding tests for [updating the PR description](https://github.com/Skyscanner/turbolift/pull/117) it becomes a nuisance that the mock github handler takes in a set number and type of arguments. This is also less than ideal for the [ClosePullRequest](https://github.com/Skyscanner/turbolift/blob/main/internal/github/fake_github.go#L50) mock implementation. This PR changes the arguments into a list of strings so we can extend the mocks without this problem.

Along the way I also removed the unused output param from the handler methods. I couldn't see any reason not to, but I might be missing one?