### PR TITLE
Revert "Revert "Clone repositories with a depth of 1 (#104)""

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,18 @@ turbolift foreach --repos repoFile2.txt sed 's/pattern2/replacement2/g'
 This creates a fork and clones all repositories listed in the `repos.txt` file (or the specified alternative repo file) into the `work` directory.
 You may wish to skip the fork and work on the upstream repository branch directly with the flag `--no-fork`.
 
-> NTLD: if one of the repositories in the list requires a fork to create a PR, omit the `--no-fork` flag and let all the repositories be forked. For now it's a all-or-nothing scenario.
+> NTLD: if one of the repositories in the list requires a fork to create a PR,
+> omit the `--no-fork` flag and let all the repositories be forked.
+> For now, it's an all-or-nothing scenario.
+
+> [!NOTE]
+> Repositories are cloned with the git flag `--depth=1`.
+> If you need the full commit history and tags, you can run the following command
+> after running `turbolift clone`:
+> 
+> ```shell
+> turbolift foreach git fetch --unshallow --tags
+> ```
 
 ### Making changes
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -72,11 +72,11 @@ func (r *RealGitHub) CreatePullRequest(output io.Writer, workingDir string, pr P
 }
 
 func (r *RealGitHub) ForkAndClone(output io.Writer, workingDir string, fullRepoName string) error {
-	return execInstance.Execute(output, workingDir, "gh", "repo", "fork", "--clone=true", "--depth=1", "--no-single-branch", fullRepoName)
+	return execInstance.Execute(output, workingDir, "gh", "repo", "fork", "--clone=true", fullRepoName, "--", "--depth=1", "--no-single-branch")
 }
 
 func (r *RealGitHub) Clone(output io.Writer, workingDir string, fullRepoName string) error {
-	return execInstance.Execute(output, workingDir, "gh", "repo", "clone", "--depth=1", "--no-single-branch", fullRepoName)
+	return execInstance.Execute(output, workingDir, "gh", "repo", "clone", fullRepoName, "--", "--depth=1", "--no-single-branch")
 }
 
 func (r *RealGitHub) ClosePullRequest(output io.Writer, workingDir string, branchName string) error {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -72,11 +72,11 @@ func (r *RealGitHub) CreatePullRequest(output io.Writer, workingDir string, pr P
 }
 
 func (r *RealGitHub) ForkAndClone(output io.Writer, workingDir string, fullRepoName string) error {
-	return execInstance.Execute(output, workingDir, "gh", "repo", "fork", "--clone=true", fullRepoName, "--", "--depth=1")
+	return execInstance.Execute(output, workingDir, "gh", "repo", "fork", "--clone=true", "--depth=1", "--no-single-branch", fullRepoName)
 }
 
 func (r *RealGitHub) Clone(output io.Writer, workingDir string, fullRepoName string) error {
-	return execInstance.Execute(output, workingDir, "gh", "repo", "clone", fullRepoName, "--", "--depth=1")
+	return execInstance.Execute(output, workingDir, "gh", "repo", "clone", "--depth=1", "--no-single-branch", fullRepoName)
 }
 
 func (r *RealGitHub) ClosePullRequest(output io.Writer, workingDir string, branchName string) error {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -72,11 +72,11 @@ func (r *RealGitHub) CreatePullRequest(output io.Writer, workingDir string, pr P
 }
 
 func (r *RealGitHub) ForkAndClone(output io.Writer, workingDir string, fullRepoName string) error {
-	return execInstance.Execute(output, workingDir, "gh", "repo", "fork", "--clone=true", fullRepoName)
+	return execInstance.Execute(output, workingDir, "gh", "repo", "fork", "--clone=true", fullRepoName, "--", "--depth=1")
 }
 
 func (r *RealGitHub) Clone(output io.Writer, workingDir string, fullRepoName string) error {
-	return execInstance.Execute(output, workingDir, "gh", "repo", "clone", fullRepoName)
+	return execInstance.Execute(output, workingDir, "gh", "repo", "clone", fullRepoName, "--", "--depth=1")
 }
 
 func (r *RealGitHub) ClosePullRequest(output io.Writer, workingDir string, branchName string) error {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -31,7 +31,7 @@ func TestItReturnsErrorOnFailedFork(t *testing.T) {
 	assert.Error(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1", "--", "--depth=1"},
+		{"work/org", "gh", "repo", "fork", "--clone=true", "--depth=1", "--no-single-branch", "org/repo1"},
 	})
 }
 
@@ -43,7 +43,7 @@ func TestItReturnsNilErrorOnSuccessfulFork(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1", "--", "--depth=1"},
+		{"work/org", "gh", "repo", "fork", "--clone=true", "--depth=1", "--no-single-branch", "org/repo1"},
 	})
 }
 
@@ -55,7 +55,7 @@ func TestItReturnsErrorOnFailedClone(t *testing.T) {
 	assert.Error(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "clone", "org/repo1", "--", "--depth=1"},
+		{"work/org", "gh", "repo", "clone", "--depth=1", "--no-single-branch", "org/repo1"},
 	})
 }
 
@@ -67,7 +67,7 @@ func TestItReturnsNilErrorOnSuccessfulClone(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "clone", "org/repo1", "--", "--depth=1"},
+		{"work/org", "gh", "repo", "clone", "--depth=1", "--no-single-branch", "org/repo1"},
 	})
 }
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -31,7 +31,7 @@ func TestItReturnsErrorOnFailedFork(t *testing.T) {
 	assert.Error(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "fork", "--clone=true", "--depth=1", "--no-single-branch", "org/repo1"},
+		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1", "--", "--depth=1", "--no-single-branch"},
 	})
 }
 
@@ -43,7 +43,7 @@ func TestItReturnsNilErrorOnSuccessfulFork(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "fork", "--clone=true", "--depth=1", "--no-single-branch", "org/repo1"},
+		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1", "--", "--depth=1", "--no-single-branch"},
 	})
 }
 
@@ -55,7 +55,7 @@ func TestItReturnsErrorOnFailedClone(t *testing.T) {
 	assert.Error(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "clone", "--depth=1", "--no-single-branch", "org/repo1"},
+		{"work/org", "gh", "repo", "clone", "org/repo1", "--", "--depth=1", "--no-single-branch"},
 	})
 }
 
@@ -67,7 +67,7 @@ func TestItReturnsNilErrorOnSuccessfulClone(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "clone", "--depth=1", "--no-single-branch", "org/repo1"},
+		{"work/org", "gh", "repo", "clone", "org/repo1", "--", "--depth=1", "--no-single-branch"},
 	})
 }
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -31,7 +31,7 @@ func TestItReturnsErrorOnFailedFork(t *testing.T) {
 	assert.Error(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1"},
+		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1", "--", "--depth=1"},
 	})
 }
 
@@ -43,7 +43,7 @@ func TestItReturnsNilErrorOnSuccessfulFork(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1"},
+		{"work/org", "gh", "repo", "fork", "--clone=true", "org/repo1", "--", "--depth=1"},
 	})
 }
 
@@ -55,7 +55,7 @@ func TestItReturnsErrorOnFailedClone(t *testing.T) {
 	assert.Error(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "clone", "org/repo1"},
+		{"work/org", "gh", "repo", "clone", "org/repo1", "--", "--depth=1"},
 	})
 }
 
@@ -67,7 +67,7 @@ func TestItReturnsNilErrorOnSuccessfulClone(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeExecutor.AssertCalledWith(t, [][]string{
-		{"work/org", "gh", "repo", "clone", "org/repo1"},
+		{"work/org", "gh", "repo", "clone", "org/repo1", "--", "--depth=1"},
 	})
 }
 


### PR DESCRIPTION
Reverts Skyscanner/turbolift#116

We are re-implementing the depth=1 feature with the addition of --no-single-branch to prevent issues as described in #104 