### PR TITLE
fix(executor): Adding silent mode and tests

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -59,8 +59,7 @@ func (e *RealExecutor) ExecuteAndCapture(output io.Writer, workingDir string, na
 	command.Dir = workingDir
 
 	if e.Verbose {
-		_, err := fmt.Fprintln(output, "Executing:", name, summarizedArgs(args), "in", workingDir)
-		if err != nil {
+		if _, err := fmt.Fprintln(output, "Executing:", name, summarizedArgs(args), "in", workingDir); err != nil {
 			return "", err
 		}
 	}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1,0 +1,124 @@
+package executor
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecutorExecuteVerbose(t *testing.T) {
+	localExecutor := NewRealExecutor()
+	outputBytes := bytes.NewBuffer([]byte{})
+
+	err := localExecutor.Execute(outputBytes, ".", "echo", "Test1234")
+	assert.NoError(t, err)
+
+	output := outputBytes.String()
+
+	assert.Contains(t, output, "Test1234")
+	assert.Contains(t, output, "Executing: echo [Test1234]")
+}
+
+func TestExecutorExecuteSilent(t *testing.T) {
+	localExecutor := NewRealExecutor()
+	localExecutor.SetVerbose(false)
+
+	outputBytes := bytes.NewBuffer([]byte{})
+
+	err := localExecutor.Execute(outputBytes, ".", "echo", "Test1234")
+	assert.NoError(t, err)
+
+	output := outputBytes.String()
+	assert.Contains(t, output, "Test1234")
+	assert.NotContains(t, output, "Executing:")
+}
+
+func TestExecutorExecuteThrowsError(t *testing.T) {
+	localExecutor := NewRealExecutor()
+
+	outputBytes := bytes.NewBuffer([]byte{})
+
+	err := localExecutor.Execute(outputBytes, ".", "fakecommand", "should", "error")
+	assert.Error(t, err)
+
+	output := outputBytes.String()
+	assert.Contains(t, output, "Executing: fakecommand [should error] in .")
+}
+
+func TestExecutorExecuteAndCaptureVerbose(t *testing.T) {
+	localExecutor := NewRealExecutor()
+	commandOutput := bytes.NewBuffer([]byte{})
+
+	output, err := localExecutor.ExecuteAndCapture(commandOutput, ".", "echo", "Test1234")
+	assert.NoError(t, err)
+
+	assert.Equal(t, output, "Test1234\n")
+	assert.Contains(t, commandOutput.String(), "Executing: echo [Test1234]")
+}
+
+func TestExecutorExecuteAndCaptureSilent(t *testing.T) {
+	localExecutor := NewRealExecutor()
+	localExecutor.SetVerbose(false)
+	commandOutput := bytes.NewBuffer([]byte{})
+
+	output, err := localExecutor.ExecuteAndCapture(commandOutput, ".", "echo", "Test1234")
+	assert.NoError(t, err)
+
+	assert.Equal(t, output, "Test1234\n")
+	assert.Empty(t, commandOutput.String())
+}
+
+func TestExecutorExecuteAndCaptureThrowsError(t *testing.T) {
+	localExecutor := NewRealExecutor()
+	commandOutput := bytes.NewBuffer([]byte{})
+
+	output, err := localExecutor.ExecuteAndCapture(commandOutput, ".", "fakecommand", "does", "not", "exist")
+	assert.Error(t, err)
+
+	assert.Empty(t, output, "Test1234\n")
+	assert.Contains(t, commandOutput.String(), "Executing: fakecommand [does not exist] in .")
+}
+
+func TestSummarizedArgs(t *testing.T) {
+	testCases := []struct {
+		TestName string
+		Input    []string
+		Expected []string
+	}{
+		{
+			TestName: "empty",
+			Input:    []string{},
+			Expected: []string{},
+		},
+		{
+			TestName: "single",
+			Input:    []string{"a"},
+			Expected: []string{"a"},
+		},
+		{
+			TestName: "multiple",
+			Input:    []string{"a", "b", "c"},
+			Expected: []string{"a", "b", "c"},
+		},
+		{
+			TestName: "One of the arg is > 30 chars",
+			Input:    []string{"a", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "c"},
+			Expected: []string{"a", "...", "c"},
+		},
+		{
+			TestName: "All Five args are long",
+			Input: []string{
+				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+				"ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			},
+			Expected: []string{"...", "...", "..."},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			assert.Equal(t, testCase.Expected, summarizedArgs(testCase.Input))
+		})
+	}
+}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -112,8 +112,10 @@ func TestSummarizedArgs(t *testing.T) {
 				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 				"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 				"ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+				"ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+				"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
 			},
-			Expected: []string{"...", "...", "..."},
+			Expected: []string{"...", "...", "...", "...", "..."},
 		},
 	}
 	for _, testCase := range testCases {

--- a/internal/executor/fake_executor.go
+++ b/internal/executor/fake_executor.go
@@ -17,9 +17,10 @@ package executor
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type FakeExecutor struct {
@@ -39,6 +40,8 @@ func (e *FakeExecutor) ExecuteAndCapture(_ io.Writer, workingDir string, name st
 	e.calls = append(e.calls, allArgs)
 	return e.ReturningHandler(workingDir, name, args...)
 }
+
+func (e *FakeExecutor) SetVerbose(_ bool) {}
 
 func (e *FakeExecutor) AssertCalledWith(t *testing.T, expected [][]string) {
 	assert.Equal(t, expected, e.calls)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -16,10 +16,11 @@
 package git
 
 import (
-	"github.com/skyscanner/turbolift/internal/executor"
 	"io"
 	"os"
 	"strconv"
+
+	"github.com/skyscanner/turbolift/internal/executor"
 )
 
 var execInstance executor.Executor = executor.NewRealExecutor()
@@ -32,8 +33,7 @@ type Git interface {
 	Pull(output io.Writer, workingDir string, remote string, branchName string) error
 }
 
-type RealGit struct {
-}
+type RealGit struct{}
 
 func (r *RealGit) Checkout(output io.Writer, workingDir string, branchName string) error {
 	return execInstance.Execute(output, workingDir, "git", "checkout", "-b", branchName)
@@ -48,13 +48,14 @@ func (r *RealGit) Commit(output io.Writer, workingDir string, message string) er
 }
 
 func (r *RealGit) IsRepoChanged(output io.Writer, workingDir string) (bool, error) {
+	var localExecutor executor.Executor = executor.NewRealExecutor()
+	localExecutor.SetVerbose(false)
 	shellCommand := os.Getenv("SHELL")
 	if shellCommand == "" {
 		shellCommand = "sh"
 	}
 	shellArgs := []string{"-c", "git status --porcelain=v1 | wc -l | tr -d '[:space:]'"}
-	commandOutput, err := execInstance.ExecuteAndCapture(output, workingDir, shellCommand, shellArgs...)
-
+	commandOutput, err := localExecutor.ExecuteAndCapture(output, workingDir, shellCommand, shellArgs...)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
# Reason for change

While looking at #94, I've notived that the output of `turbolift commit`
includes a weird line:

```
Executing: /opt/homebrew/bin/zsh [-c ...]
```

<img width="793" alt="image" src="https://github.com/Skyscanner/turbolift/assets/1921711/4f7f18f5-a950-470e-837c-b8ee230fcd77">

This is because `isRepoChanged` [function](https://github.com/Skyscanner/turbolift/blob/main/internal/git/git.go#L56) executes a command to figure out whether something is marked as changed. Every command executed generates an [echo of the command](https://github.com/Skyscanner/turbolift/blob/main/internal/executor/executor.go#L61) for the user.

# What's changed?

This PR introduces a new flag on the executor that will skip the echo.
This fixes the extraneous output in `isRepoChanged` but will also be useful in future features.

It also adds unit tests on the `executor` package which were missing before.
The tests highlighted a race condition that went unnoticed previously and is also now fixed.

# Result of the PR

The extra line doesn't print any more.
<img width="738" alt="image" src="https://github.com/Skyscanner/turbolift/assets/1921711/98accdf3-a0fe-4326-9462-14868a2a7e62">
