### PR TITLE
Add build status to pr-status list table

### DIFF
--- a/cmd/prstatus/prstatus.go
+++ b/cmd/prstatus/prstatus.go
@@ -88,7 +88,7 @@ func run(c *cobra.Command, _ []string) {
 	statuses := make(map[string]int)
 	reactions := make(map[string]int)
 
-	detailsTable := table.New("Repository", "State", "Reviews", "URL")
+	detailsTable := table.New("Repository", "State", "Reviews", "Build status", "URL")
 	detailsTable.WithHeaderFormatter(color.New(color.Underline).SprintfFunc())
 	detailsTable.WithFirstColumnFormatter(color.New(color.FgCyan).SprintfFunc())
 	detailsTable.WithWriter(logger.Writer())
@@ -118,7 +118,7 @@ func run(c *cobra.Command, _ []string) {
 			reactions[reaction.Content] += reaction.Users.TotalCount
 		}
 
-		detailsTable.AddRow(repo.FullRepoName, prStatus.State, prStatus.ReviewDecision, prStatus.Url)
+		detailsTable.AddRow(repo.FullRepoName, prStatus.State, prStatus.ReviewDecision, prStatus.Mergeable, prStatus.Url)
 
 		checkStatusActivity.EndWithSuccess()
 	}

--- a/cmd/prstatus/prstatus_test.go
+++ b/cmd/prstatus/prstatus_test.go
@@ -64,9 +64,9 @@ func TestItLogsDetailedInformation(t *testing.T) {
 	assert.Regexp(t, "Open\\s+1", out)
 	assert.Regexp(t, "👍\\s+4", out)
 
-	assert.Regexp(t, "org/repo1\\s+OPEN\\s+REVIEW_REQUIRED", out)
-	assert.Regexp(t, "org/repo2\\s+MERGED\\s+APPROVED", out)
-	assert.Regexp(t, "org/repo3\\s+CLOSED", out)
+	assert.Regexp(t, "org/repo1\\s+OPEN\\s+REVIEW_REQUIRED\\s+MERGEABLE", out)
+	assert.Regexp(t, "org/repo2\\s+MERGED\\s+APPROVED\\s+UNKNOWN", out)
+	assert.Regexp(t, "org/repo3\\s+CLOSED\\s+UNKNOWN", out)
 }
 
 func TestItSkipsUnclonedRepos(t *testing.T) {
@@ -119,6 +119,7 @@ func prepareFakeResponses() {
 	dummyData := map[string]*github.PrStatus{
 		"work/org/repo1": {
 			State: "OPEN",
+			Mergeable: "MERGEABLE",
 			ReactionGroups: []github.ReactionGroup{
 				{
 					Content: "THUMBS_UP",
@@ -137,6 +138,7 @@ func prepareFakeResponses() {
 		},
 		"work/org/repo2": {
 			State: "MERGED",
+			Mergeable: "UNKNOWN",
 			ReactionGroups: []github.ReactionGroup{
 				{
 					Content: "THUMBS_UP",
@@ -149,6 +151,7 @@ func prepareFakeResponses() {
 		},
 		"work/org/repo3": {
 			State: "CLOSED",
+			Mergeable: "UNKNOWN",
 			ReactionGroups: []github.ReactionGroup{
 				{
 					Content: "THUMBS_DOWN",


### PR DESCRIPTION
Adding the Build status to the pr-status list command using the `Mergeable` field which was already available