### PR TITLE
fix(foreach): supports quoted commands

### DIFF
--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -16,9 +16,9 @@
 package foreach
 
 import (
-	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -101,7 +101,7 @@ func run(c *cobra.Command, args []string) {
 
 	for i := range args {
 		if strings.Contains(args[i], " ") {
-			args[i] = fmt.Sprintf(`"%s"`, args[i])
+			args[i] = strconv.Quote(args[i])
 		}
 	}
 	command := strings.Join(args, " ")

--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -16,6 +16,7 @@
 package foreach
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -100,7 +101,7 @@ func run(c *cobra.Command, args []string) {
 
 	for i := range args {
 		if strings.Contains(args[i], " ") {
-			args[i] = "\"" + args[i] + "\""
+			args[i] = fmt.Sprintf(`"%s"`, args[i])
 		}
 	}
 	command := strings.Join(args, " ")

--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -98,10 +98,16 @@ func run(c *cobra.Command, args []string) {
 	}
 	readCampaignActivity.EndWithSuccess()
 
+	for i := range args {
+		if strings.Contains(args[i], " ") {
+			args[i] = "\"" + args[i] + "\""
+		}
+	}
+	command := strings.Join(args, " ")
+
 	var doneCount, skippedCount, errorCount int
 	for _, repo := range dir.Repos {
 		repoDirPath := path.Join("work", repo.OrgName, repo.RepoName) // i.e. work/org/repo
-		command := strings.Join(args, " ")
 
 		execActivity := logger.StartActivity("Executing %s in %s", command, repoDirPath)
 

--- a/cmd/foreach/foreach_test.go
+++ b/cmd/foreach/foreach_test.go
@@ -151,6 +151,23 @@ func TestItRunsCommandInShellAgainstWorkingCopies(t *testing.T) {
 	})
 }
 
+func TestItRunsCommandQuotedInShellAgainstWorkingCopied(t *testing.T) {
+	fakeExecutor := executor.NewAlwaysSucceedsFakeExecutor()
+	exec = fakeExecutor
+
+	testsupport.PrepareTempCampaign(true, "org/repo1", "org/repo2")
+
+	out, err := runCommand("some", "command", "with spaces")
+	assert.NoError(t, err)
+	assert.Contains(t, out, "turbolift foreach completed")
+	assert.Contains(t, out, "2 OK, 0 skipped")
+
+	fakeExecutor.AssertCalledWith(t, [][]string{
+		{"work/org/repo1", userShell(), "-c", "some command \"with spaces\""},
+		{"work/org/repo2", userShell(), "-c", "some command \"with spaces\""},
+	})
+}
+
 func TestItSkipsMissingWorkingCopies(t *testing.T) {
 	fakeExecutor := executor.NewAlwaysSucceedsFakeExecutor()
 	exec = fakeExecutor


### PR DESCRIPTION
This PR allows to execute foreach commands with parameters that include spaces.

```sh
turbolift foreach git commit -a -m "my commit that usually has spaces"
turbolift foreach sed -i 's/text with spaces/text-without-spaces/g' README.md
```

Also improves the code by reusing the same command slice for all the repositories.
