### PR TITLE
feat(GHA): adding conventional commit linting

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,14 @@
+---
+name: Lint Commit Messages
+on: [pull_request]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wagoid/commitlint-github-action@v6


### PR DESCRIPTION
Using a PR to kick off a conversation about conventional commit styles
and whether we should use it for turbolift.

I've been using it and seen it used here and there on many open source
repositories and seems to be wide spread.

# Change

Adding a new github action step as linting for commit messages.

# What will the commit message look like?

From the documentation, they will follow this convention:
```
<type>[optional scope]: <description>
```

Where type can be:
- `fix` (typically a bug fix)
- `feat` (a new feature)
- `chore` (for engineering health)
- `refactor` and many more.

A typical commit message would look like:
```
feat(api): send an email to the customer when a product is shipped
```

# Why?

Lots of OS repositories seem to have adopted the [conventional commit
style] (https://www.conventionalcommits.org/en/v1.0.0/#summary).

This PR is a simple check on the commit message, giving the commiter
feedback on the commit message style.

This could be complemented by a precommit check if we revisit it.
