### PR TITLE
fix(clone): provide helpful message when fork conflicts cause an error

### DIFF
--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -126,7 +126,7 @@ func run(c *cobra.Command, _ []string) {
 			err = g.Pull(pullFromUpstreamActivity.Writer(), repoDirPath, "upstream", defaultBranch)
 			if err != nil {
 				pullFromUpstreamActivity.EndWithFailure(err)
-				logger.Printf("We weren't able to pull the latest upstream changes into your fork of %s. This is probably because you have a pre-existing fork with commits ahead of upstream. Please change this or delete your fork, and try again.", repo.FullRepoName)
+				logger.Printf("\nWe weren't able to pull the latest upstream changes into your fork of %s. This is probably because you have a pre-existing fork with commits ahead of upstream. Please change this or delete your fork, and try again.\n", repo.FullRepoName)
 				errorCount++
 				continue
 			}

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -126,6 +126,7 @@ func run(c *cobra.Command, _ []string) {
 			err = g.Pull(pullFromUpstreamActivity.Writer(), repoDirPath, "upstream", defaultBranch)
 			if err != nil {
 				pullFromUpstreamActivity.EndWithFailure(err)
+				logger.Printf("We weren't able to pull the latest upstream changes into your fork of %s. This is probably because you have a pre-existing fork with commits ahead of upstream. Please change this or delete your fork, and try again.", repo.FullRepoName)
 				errorCount++
 				continue
 			}

--- a/cmd/clone/clone_test.go
+++ b/cmd/clone/clone_test.go
@@ -204,6 +204,8 @@ func TestItLogsPullErrorsButContinuesToTryAll(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, out, "Pulling latest changes from org1/repo1")
 	assert.Contains(t, out, "Pulling latest changes from org2/repo2")
+	assert.Contains(t, out, "We weren't able to pull the latest upstream changes into your fork of org1/repo1")
+	assert.Contains(t, out, "We weren't able to pull the latest upstream changes into your fork of org2/repo2")
 	assert.Contains(t, out, "turbolift clone completed with errors")
 	assert.Contains(t, out, "2 repos errored")
 


### PR DESCRIPTION
An option to deal with https://github.com/Skyscanner/turbolift/issues/128