### PR TITLE
Add file output to foreach command

### DIFF
--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -17,6 +17,7 @@ package foreach
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -49,8 +50,7 @@ func NewForeachCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "foreach [flags] -- COMMAND [ARGUMENT...]",
 		Short: "Run COMMAND against each working copy",
-		Long:
-`Run COMMAND against each working copy. Make sure to include a
+		Long: `Run COMMAND against each working copy. Make sure to include a
 double hyphen -- with space on both sides before COMMAND, as this
 marks that no further options should be interpreted by turbolift.`,
 		RunE: runE,
@@ -83,6 +83,10 @@ func runE(c *cobra.Command, args []string) error {
 	// the user something they could copy and paste.
 	prettyArgs := formatArguments(args)
 
+	o := setupOutputFiles(dir.Name, prettyArgs)
+
+	logger.Printf("Logs for all executions will be stored under %s", o.overallResultsDirectory)
+
 	var doneCount, skippedCount, errorCount int
 	for _, repo := range dir.Repos {
 		repoDirPath := path.Join("work", repo.OrgName, repo.RepoName) // i.e. work/org/repo
@@ -101,7 +105,9 @@ func runE(c *cobra.Command, args []string) error {
 		if err != nil {
 			execActivity.EndWithFailure(err)
 			errorCount++
+			emitOutcomeToFiles(repo, o.failedReposFile, o.failedResultsDirectory, execActivity.Logs(), logger)
 		} else {
+			emitOutcomeToFiles(repo, o.successfulReposFile, o.successfulResultsDirectory, execActivity.Logs(), logger)
 			execActivity.EndWithSuccessAndEmitLogs()
 			doneCount++
 		}
@@ -113,5 +119,70 @@ func runE(c *cobra.Command, args []string) error {
 		logger.Warnf("turbolift foreach completed with %s %s(%s, %s, %s)\n", colors.Red("errors"), colors.Normal(), colors.Green(doneCount, " OK"), colors.Yellow(skippedCount, " skipped"), colors.Red(errorCount, " errored"))
 	}
 
+	logger.Printf("Logs for all executions have been stored under %s", o.overallResultsDirectory)
+	logger.Printf("Names of successful repos have been written to %s", o.successfulReposFile.Name())
+	logger.Printf("Names of failed repos have been written to %s", o.failedReposFile.Name())
+
 	return nil
+}
+
+type outputLogFileDestinations struct {
+	overallResultsDirectory string
+
+	successfulResultsDirectory string
+	successfulReposFile        *os.File
+
+	failedResultsDirectory string
+	failedReposFile        *os.File
+}
+
+// sets up a temporary directory to store success/failure logs etc
+func setupOutputFiles(campaignName string, command string) outputLogFileDestinations {
+	resultsDirectory, _ := os.MkdirTemp("", fmt.Sprintf("turbolift-foreach-%s-", campaignName))
+	successfulResultsDirectory := path.Join(resultsDirectory, "successful")
+	failedResultsDirectory := path.Join(resultsDirectory, "failed")
+	_ = os.MkdirAll(successfulResultsDirectory, 0755)
+	_ = os.MkdirAll(failedResultsDirectory, 0755)
+
+	successfulReposTxt := path.Join(successfulResultsDirectory, "repos.txt")
+	failedReposTxt := path.Join(failedResultsDirectory, "repos.txt")
+
+	// create the files
+	successfulReposFile, _ := os.Create(successfulReposTxt)
+	failedReposFile, _ := os.Create(failedReposTxt)
+
+	_, _ = successfulReposFile.WriteString(fmt.Sprintf("# This file contains the list of repositories that were successfully processed by turbolift foreach\n# for the command: %s\n", command))
+	_, _ = failedReposFile.WriteString(fmt.Sprintf("# This file contains the list of repositories that failed to be processed by turbolift foreach\n# for the command: %s\n", command))
+
+	return outputLogFileDestinations{
+		overallResultsDirectory: resultsDirectory,
+
+		successfulResultsDirectory: successfulResultsDirectory,
+		successfulReposFile:        successfulReposFile,
+
+		failedResultsDirectory: failedResultsDirectory,
+		failedReposFile:        failedReposFile,
+	}
+}
+
+func emitOutcomeToFiles(repo campaign.Repo, reposFile *os.File, logsDirectoryParent string, executionLogs string, logger *logging.Logger) {
+	// write the repo name to the repos file
+	_, err := reposFile.WriteString(repo.FullRepoName + "\n")
+	if err != nil {
+		logger.Errorf("Failed to write repo name to %s: %s", reposFile.Name(), err)
+	}
+
+	// write logs to a file under the logsParent directory, in a directory structure that mirrors that of the work directory
+	logsDir := path.Join(logsDirectoryParent, repo.FullRepoName)
+	logsFile := path.Join(logsDir, "logs.txt")
+	err = os.MkdirAll(logsDir, 0755)
+	if err != nil {
+		logger.Errorf("Failed to create directory %s: %s", logsDir, err)
+	}
+
+	logs, _ := os.Create(logsFile)
+	_, err = logs.WriteString(executionLogs)
+	if err != nil {
+		logger.Errorf("Failed to write logs to %s: %s", logsFile, err)
+	}
 }

--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -148,21 +148,21 @@ func setupOutputFiles(campaignName string, command string) {
 	// create the files
 	successfulReposFile, _ := os.Create(successfulReposFileName)
 	failedReposFile, _ := os.Create(failedReposFileName)
+	defer successfulReposFile.Close()
+	defer failedReposFile.Close()
 
 	_, _ = successfulReposFile.WriteString(fmt.Sprintf("# This file contains the list of repositories that were successfully processed by turbolift foreach\n# for the command: %s\n", command))
 	_, _ = failedReposFile.WriteString(fmt.Sprintf("# This file contains the list of repositories that failed to be processed by turbolift foreach\n# for the command: %s\n", command))
-	successfulReposFile.Close()
-	failedReposFile.Close()
 }
 
 func emitOutcomeToFiles(repo campaign.Repo, reposFileName string, logsDirectoryParent string, executionLogs string, logger *logging.Logger) {
 	// write the repo name to the repos file
 	reposFile, _ := os.OpenFile(reposFileName, os.O_RDWR|os.O_APPEND, 0644)
+	defer reposFile.Close()
 	_, err := reposFile.WriteString(repo.FullRepoName + "\n")
 	if err != nil {
 		logger.Errorf("Failed to write repo name to %s: %s", reposFile.Name(), err)
 	}
-	reposFile.Close()
 
 	// write logs to a file under the logsParent directory, in a directory structure that mirrors that of the work directory
 	logsDir := path.Join(logsDirectoryParent, repo.FullRepoName)
@@ -173,9 +173,9 @@ func emitOutcomeToFiles(repo campaign.Repo, reposFileName string, logsDirectoryP
 	}
 
 	logs, _ := os.Create(logsFile)
+	defer logs.Close()
 	_, err = logs.WriteString(executionLogs)
 	if err != nil {
 		logger.Errorf("Failed to write logs to %s: %s", logsFile, err)
 	}
-	logs.Close()
 }

--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -103,9 +103,9 @@ func runE(c *cobra.Command, args []string) error {
 		err := exec.Execute(execActivity.Writer(), repoDirPath, args[0], args[1:]...)
 
 		if err != nil {
+			emitOutcomeToFiles(repo, o.failedReposFile, o.failedResultsDirectory, execActivity.Logs(), logger)
 			execActivity.EndWithFailure(err)
 			errorCount++
-			emitOutcomeToFiles(repo, o.failedReposFile, o.failedResultsDirectory, execActivity.Logs(), logger)
 		} else {
 			emitOutcomeToFiles(repo, o.successfulReposFile, o.successfulResultsDirectory, execActivity.Logs(), logger)
 			execActivity.EndWithSuccessAndEmitLogs()

--- a/internal/executor/fake_executor.go
+++ b/internal/executor/fake_executor.go
@@ -70,3 +70,25 @@ func NewAlwaysFailsFakeExecutor() *FakeExecutor {
 		return "", errors.New("synthetic error")
 	})
 }
+
+func NewAlternatingSuccessFakeExecutor() *FakeExecutor {
+	i := 0
+	return NewFakeExecutor(
+		func(s string, s2 string, s3 ...string) error {
+			i++
+			if i%2 == 1 {
+				return nil
+			} else {
+				return errors.New("synthetic error")
+			}
+		},
+		func(s string, s2 string, s3 ...string) (string, error) {
+			i++
+			if i%2 == 1 {
+				return "", nil
+			} else {
+				return "", errors.New("synthetic error")
+			}
+		},
+	)
+}

--- a/internal/logging/activity.go
+++ b/internal/logging/activity.go
@@ -110,3 +110,7 @@ func (a *Activity) Writer() io.Writer {
 		activity: a,
 	}
 }
+
+func (a *Activity) Logs() string {
+	return strings.Join(a.logs, "\n")
+}


### PR DESCRIPTION
Fixes #7 

When running `turbolift foreach` there are several frequent use cases that are ill catered for:

* reviewing the logs on a per-repo basis - logs are currently in one giant scrollback
* reviewing just failure or just success logs
* (very often) gathering the names of the repos where the command succeeded or failed - for example, when running foreach to run tests

To avoid further cluttering the terminal output, this PR:
* Creates a temp directory each time it's run, which will likely exist until system reboot
* In that directory creates the following structure, where `org/repo/logs.txt` is repeated for every repository (mirroring the structure of the `work` directory):

```
some-temp-dir
   \ successful
       \ repos.txt        # a list of repos where the command succeeded
       \ org
           \ repo
               \ logs.txt # logs from the specific foreach execution on this repo
           ....
   \ failed
       \ repos.txt        # a list of repos where the command succeeded
       \ org
           \ repo
               \ logs.txt # logs from the specific foreach execution on this repo
           ....
```

Some notable points:
* the emitted `repos.txt` files are suitable for replay back into turbolift using the `-r` option
* we don't stop the current logging to terminal output - this is mainly for backwards compatibility
