### PR TITLE
feat(create_prs): check whether PR description file has been updated

### DIFF
--- a/cmd/create_prs/create_prs.go
+++ b/cmd/create_prs/create_prs.go
@@ -20,6 +20,7 @@ import (
 	"github.com/skyscanner/turbolift/internal/prompt"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -72,7 +73,7 @@ func run(c *cobra.Command, _ []string) {
 		return
 	}
 	if prDescriptionUnchanged(dir) {
-		if !p.AskConfirm(fmt.Sprintf("It looks like the PR title and/or description has not been updated in %s. Are you sure you want to proceed?", prDescriptionFile)) {
+		if !p.AskConfirm(fmt.Sprintf("It looks like the PR title and/or description may not have been updated in %s. Are you sure you want to proceed?", prDescriptionFile)) {
 			return
 		}
 	}
@@ -141,16 +142,7 @@ func run(c *cobra.Command, _ []string) {
 }
 
 func prDescriptionUnchanged(dir *campaign.Campaign) bool {
-	originalPrTitle := fmt.Sprintf("TODO: Title of Pull Request (%s)", dir.Name)
-	originalPrBody := `TODO: This file will serve as both a README and the description of the PR. Describe the pull request using markdown in this file. Make it clear why the change is being made, and make suggestions for anything that the reviewer may need to do.
-
-By approving this PR, you are confirming that you have adequately and effectively reviewed this change.
-
-## How this change was made
-TODO: Describe the approach that was used to select repositories for this change
-TODO: Describe any shell commands, scripts, manual operations, etc, that were used to make changes
-
-<!-- Please keep the footer below, to support turbolift usage tracking -->
-<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>`
-	return dir.PrTitle == originalPrTitle || dir.PrBody == originalPrBody || dir.PrTitle == ""
+	originalPrTitleTodo := fmt.Sprintf("TODO: Title of Pull Request (%s)", dir.Name)
+	originalPrBodyTodo := "TODO: This file will serve as both a README and the description of the PR."
+	return dir.PrTitle == originalPrTitleTodo || strings.Contains(dir.PrBody, originalPrBodyTodo) || dir.PrTitle == ""
 }

--- a/cmd/create_prs/create_prs.go
+++ b/cmd/create_prs/create_prs.go
@@ -142,7 +142,7 @@ func run(c *cobra.Command, _ []string) {
 }
 
 func prDescriptionUnchanged(dir *campaign.Campaign) bool {
-	originalPrTitleTodo := fmt.Sprintf("TODO: Title of Pull Request (%s)", dir.Name)
+	originalPrTitleTodo := "TODO: Title of Pull Request"
 	originalPrBodyTodo := "TODO: This file will serve as both a README and the description of the PR."
-	return dir.PrTitle == originalPrTitleTodo || strings.Contains(dir.PrBody, originalPrBodyTodo) || dir.PrTitle == ""
+	return strings.Contains(dir.PrTitle, originalPrTitleTodo) || strings.Contains(dir.PrBody, originalPrBodyTodo) || dir.PrTitle == ""
 }

--- a/cmd/create_prs/create_prs_test.go
+++ b/cmd/create_prs/create_prs_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/skyscanner/turbolift/internal/prompt"
 	"github.com/skyscanner/turbolift/internal/testsupport"
 	"github.com/stretchr/testify/assert"
-	"path/filepath"
 	"testing"
 )
 
@@ -34,8 +33,8 @@ func TestItWarnsIfDescriptionFileTemplateIsUnchanged(t *testing.T) {
 	fakePrompt := prompt.NewFakePromptNo()
 	p = fakePrompt
 
-	dirName := testsupport.PrepareTempCampaign(true, "org/repo1", "org/repo2")
-	testsupport.UseDefaultPrDescription(dirName)
+	testsupport.PrepareTempCampaign(true, "org/repo1", "org/repo2")
+	testsupport.UseDefaultPrDescription()
 
 	out, err := runCommand()
 	assert.NoError(t, err)
@@ -55,8 +54,8 @@ func TestItWarnsIfOnlyPrTitleIsUnchanged(t *testing.T) {
 	fakePrompt := prompt.NewFakePromptNo()
 	p = fakePrompt
 
-	dirName := testsupport.PrepareTempCampaign(true, "org/repo1", "org/repo2")
-	testsupport.UsePrTitleTodoOnly(filepath.Base(dirName))
+	testsupport.PrepareTempCampaign(true, "org/repo1", "org/repo2")
+	testsupport.UsePrTitleTodoOnly()
 
 	out, err := runCommand()
 	assert.NoError(t, err)

--- a/cmd/create_prs/create_prs_test.go
+++ b/cmd/create_prs/create_prs_test.go
@@ -43,7 +43,7 @@ func TestItWarnsIfDescriptionFileTemplateIsUnchanged(t *testing.T) {
 	assert.NotContains(t, out, "turbolift create-prs completed")
 	assert.NotContains(t, out, "2 OK, 0 skipped")
 
-	fakePrompt.AssertCalledWith(t, "It looks like the PR title and/or description has not been updated in README.md. Are you sure you want to proceed?")
+	fakePrompt.AssertCalledWith(t, "It looks like the PR title and/or description may not have been updated in README.md. Are you sure you want to proceed?")
 }
 
 func TestItWarnsIfDescriptionFileIsEmpty(t *testing.T) {
@@ -66,7 +66,7 @@ func TestItWarnsIfDescriptionFileIsEmpty(t *testing.T) {
 	assert.NotContains(t, out, "turbolift create-prs completed")
 	assert.NotContains(t, out, "2 OK, 0 skipped")
 
-	fakePrompt.AssertCalledWith(t, "It looks like the PR title and/or description has not been updated in custom.md. Are you sure you want to proceed?")
+	fakePrompt.AssertCalledWith(t, "It looks like the PR title and/or description may not have been updated in custom.md. Are you sure you want to proceed?")
 }
 
 func TestItLogsCreatePrErrorsButContinuesToTryAll(t *testing.T) {

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -2,8 +2,10 @@ package prompt
 
 import (
 	"strings"
+	"testing"
 
 	"github.com/manifoldco/promptui"
+	"github.com/stretchr/testify/assert"
 )
 
 type Prompt interface {
@@ -49,12 +51,19 @@ func (f FakePromptYes) AskConfirm(_ string) bool {
 }
 
 // Mock Prompt that always returns false
-type FakePromptNo struct{}
+type FakePromptNo struct {
+	call string
+}
 
 func NewFakePromptNo() *FakePromptNo {
 	return &FakePromptNo{}
 }
 
-func (f FakePromptNo) AskConfirm(_ string) bool {
+func (f *FakePromptNo) AskConfirm(question string) bool {
+	f.call = question
 	return false
+}
+
+func (f *FakePromptNo) AssertCalledWith(t *testing.T, expected string) {
+	assert.Equal(t, expected, f.call)
 }

--- a/internal/testsupport/testsupport.go
+++ b/internal/testsupport/testsupport.go
@@ -81,3 +81,18 @@ func CreateOrUpdatePrDescriptionFile(filename string, prTitle string, prBody str
 		panic(err)
 	}
 }
+
+func UseDefaultPrDescription(dirName string) {
+	originalPrTitle := fmt.Sprintf("TODO: Title of Pull Request (%s)", dirName)
+	originalPrBody := `TODO: This file will serve as both a README and the description of the PR. Describe the pull request using markdown in this file. Make it clear why the change is being made, and make suggestions for anything that the reviewer may need to do.
+
+By approving this PR, you are confirming that you have adequately and effectively reviewed this change.
+
+## How this change was made
+TODO: Describe the approach that was used to select repositories for this change
+TODO: Describe any shell commands, scripts, manual operations, etc, that were used to make changes
+
+<!-- Please keep the footer below, to support turbolift usage tracking -->
+<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>`
+	CreateOrUpdatePrDescriptionFile("README.md", originalPrTitle, originalPrBody)
+}

--- a/internal/testsupport/testsupport.go
+++ b/internal/testsupport/testsupport.go
@@ -24,6 +24,9 @@ import (
 	"strings"
 )
 
+var originalPrTitleTodo = "TODO: Title of Pull Request"
+var originalPrBodyTodo = "TODO: This file will serve as both a README and the description of the PR."
+
 func Pwd() string {
 	dir, _ := os.Getwd()
 	return filepath.Base(dir)
@@ -83,15 +86,13 @@ func CreateOrUpdatePrDescriptionFile(filename string, prTitle string, prBody str
 }
 
 func UseDefaultPrDescription() {
-	originalPrTitleTodo := "TODO: Title of Pull Request"
-	originalPrBodyTodo := "TODO: This file will serve as both a README and the description of the PR."
 	CreateOrUpdatePrDescriptionFile("README.md", originalPrTitleTodo, originalPrBodyTodo)
 }
 
 func UsePrTitleTodoOnly() {
-	CreateOrUpdatePrDescriptionFile("README.md", "TODO: Title of Pull Request", "updated PR body")
+	CreateOrUpdatePrDescriptionFile("README.md", originalPrTitleTodo, "updated PR body")
 }
 
 func UsePrBodyTodoOnly() {
-	CreateOrUpdatePrDescriptionFile("README.md", "updated PR title", "TODO: This file will serve as both a README and the description of the PR.")
+	CreateOrUpdatePrDescriptionFile("README.md", "updated PR title", originalPrBodyTodo)
 }

--- a/internal/testsupport/testsupport.go
+++ b/internal/testsupport/testsupport.go
@@ -82,14 +82,14 @@ func CreateOrUpdatePrDescriptionFile(filename string, prTitle string, prBody str
 	}
 }
 
-func UseDefaultPrDescription(dirName string) {
-	originalPrTitleTodo := fmt.Sprintf("TODO: Title of Pull Request (%s)", dirName)
+func UseDefaultPrDescription() {
+	originalPrTitleTodo := "TODO: Title of Pull Request"
 	originalPrBodyTodo := "TODO: This file will serve as both a README and the description of the PR."
 	CreateOrUpdatePrDescriptionFile("README.md", originalPrTitleTodo, originalPrBodyTodo)
 }
 
-func UsePrTitleTodoOnly(dirName string) {
-	CreateOrUpdatePrDescriptionFile("README.md", fmt.Sprintf("TODO: Title of Pull Request (%s)", dirName), "updated PR body")
+func UsePrTitleTodoOnly() {
+	CreateOrUpdatePrDescriptionFile("README.md", "TODO: Title of Pull Request", "updated PR body")
 }
 
 func UsePrBodyTodoOnly() {

--- a/internal/testsupport/testsupport.go
+++ b/internal/testsupport/testsupport.go
@@ -87,3 +87,11 @@ func UseDefaultPrDescription(dirName string) {
 	originalPrBodyTodo := "TODO: This file will serve as both a README and the description of the PR."
 	CreateOrUpdatePrDescriptionFile("README.md", originalPrTitleTodo, originalPrBodyTodo)
 }
+
+func UsePrTitleTodoOnly(dirName string) {
+	CreateOrUpdatePrDescriptionFile("README.md", fmt.Sprintf("TODO: Title of Pull Request (%s)", dirName), "updated PR body")
+}
+
+func UsePrBodyTodoOnly() {
+	CreateOrUpdatePrDescriptionFile("README.md", "updated PR title", "TODO: This file will serve as both a README and the description of the PR.")
+}

--- a/internal/testsupport/testsupport.go
+++ b/internal/testsupport/testsupport.go
@@ -83,16 +83,7 @@ func CreateOrUpdatePrDescriptionFile(filename string, prTitle string, prBody str
 }
 
 func UseDefaultPrDescription(dirName string) {
-	originalPrTitle := fmt.Sprintf("TODO: Title of Pull Request (%s)", dirName)
-	originalPrBody := `TODO: This file will serve as both a README and the description of the PR. Describe the pull request using markdown in this file. Make it clear why the change is being made, and make suggestions for anything that the reviewer may need to do.
-
-By approving this PR, you are confirming that you have adequately and effectively reviewed this change.
-
-## How this change was made
-TODO: Describe the approach that was used to select repositories for this change
-TODO: Describe any shell commands, scripts, manual operations, etc, that were used to make changes
-
-<!-- Please keep the footer below, to support turbolift usage tracking -->
-<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>`
-	CreateOrUpdatePrDescriptionFile("README.md", originalPrTitle, originalPrBody)
+	originalPrTitleTodo := fmt.Sprintf("TODO: Title of Pull Request (%s)", dirName)
+	originalPrBodyTodo := "TODO: This file will serve as both a README and the description of the PR."
+	CreateOrUpdatePrDescriptionFile("README.md", originalPrTitleTodo, originalPrBodyTodo)
 }


### PR DESCRIPTION
To deal with https://github.com/Skyscanner/turbolift/issues/124

Also adds a missing test for creating PRs with custom description file.

Replacing https://github.com/Skyscanner/turbolift/pull/130 which was unnecessarily complicated. Checking the title and body `TODOs`, which definitely should not be wanted by the user, should achieve the same thing.

The only downside of this is that if we change the template, we'll have to change strings in a couple of other places as well. But this will happen very rarely and will be easy to notice.