### PR TITLE
feat!(clone): Use better cloning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Making changes with turbolift is split into six main phases:
 
 1. `init` - getting set up
 2. Identifying the repos to operate upon
-3. Running a mass `clone` of the repos (by default, it will create a fork in your user space)
+3. Running a mass `clone` of the repos
 4. Making changes to every repo
 5. Committing changes to every repo
 6. Creating a PR for every repo
@@ -115,15 +115,17 @@ turbolift foreach --repos repoFile1.txt -- sed 's/pattern1/replacement1/g'
 turbolift foreach --repos repoFile2.txt -- sed 's/pattern2/replacement2/g'
 ```
 
-
 ### Running a mass `clone`
 
-```turbolift clone```
+`turbolift clone` clones all repositories listed in the `repos.txt` file into the `work` directory.
+By default the cloning policy is to create a branch to the target repository. If you do not have permissions to push a branch on the target repository, `turbolift` will fork it.
 
-This creates a fork and clones all repositories listed in the `repos.txt` file (or the specified alternative repo file) into the `work` directory.
-You may wish to skip the fork and work on the upstream repository branch directly with the flag `--no-fork`.
+If you do want to fork all the repositories instead of letting turbolift deciding for you, use the `--fork` flag.
 
-> NTLD: if one of the repositories in the list requires a fork to create a PR, omit the `--no-fork` flag and let all the repositories be forked. For now it's a all-or-nothing scenario.
+Usage:
+```console
+turbolift clone
+```
 
 ### Making changes
 

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -34,8 +34,8 @@ var (
 )
 
 var (
-	nofork   bool
-	repoFile string
+	forceFork bool
+	repoFile  string
 )
 
 func NewCloneCmd() *cobra.Command {
@@ -45,7 +45,7 @@ func NewCloneCmd() *cobra.Command {
 		Run:   run,
 	}
 
-	cmd.Flags().BoolVar(&nofork, "no-fork", false, "Will not fork, just clone and create a branch.")
+	cmd.Flags().BoolVar(&forceFork, "fork", false, "Force forking, instead of turbolift attempting to branch push")
 	cmd.Flags().StringVar(&repoFile, "repos", "repos.txt", "A file containing a list of repositories to clone.")
 
 	return cmd
@@ -66,10 +66,27 @@ func run(c *cobra.Command, _ []string) {
 
 	var doneCount, skippedCount, errorCount int
 	for _, repo := range dir.Repos {
-		orgDirPath := path.Join("work", repo.OrgName) // i.e. work/org
+		orgDirPath := path.Join("work", repo.OrgName)       // i.e. work/org
+		repoDirPath := path.Join(orgDirPath, repo.RepoName) // i.e. work/org/repo
 
 		var cloneActivity *logging.Activity
-		if nofork {
+
+		// Determine whether we need to fork or clone
+		var fork bool
+
+		if forceFork {
+			fork = true
+		} else {
+			res, err := gh.IsPushable(logger.Writer(), repoDirPath)
+			if err != nil {
+				logger.Warnf("Unable to determine if we can push to %s: %s", orgDirPath, err)
+				fork = true
+			} else {
+				fork = !res
+			}
+		}
+
+		if !fork {
 			cloneActivity = logger.StartActivity("Cloning %s into %s/%s", repo.FullRepoName, orgDirPath, repo.RepoName)
 		} else {
 			cloneActivity = logger.StartActivity("Forking and cloning %s into %s/%s", repo.FullRepoName, orgDirPath, repo.RepoName)
@@ -82,7 +99,6 @@ func run(c *cobra.Command, _ []string) {
 			break
 		}
 
-		repoDirPath := path.Join(orgDirPath, repo.RepoName) // i.e. work/org/repo
 		// skip if the working copy is already cloned
 		if _, err = os.Stat(repoDirPath); !os.IsNotExist(err) {
 			cloneActivity.EndWithWarningf("Directory already exists")
@@ -90,7 +106,7 @@ func run(c *cobra.Command, _ []string) {
 			continue
 		}
 
-		if nofork {
+		if !fork {
 			err = gh.Clone(cloneActivity.Writer(), orgDirPath, repo.FullRepoName)
 		} else {
 			err = gh.ForkAndClone(cloneActivity.Writer(), orgDirPath, repo.FullRepoName)
@@ -114,7 +130,7 @@ func run(c *cobra.Command, _ []string) {
 		}
 		createBranchActivity.EndWithSuccess()
 
-		if !nofork {
+		if fork {
 			pullFromUpstreamActivity := logger.StartActivity("Pulling latest changes from %s", repo.FullRepoName)
 			var defaultBranch string
 			defaultBranch, err = gh.GetDefaultBranchName(pullFromUpstreamActivity.Writer(), repoDirPath, repo.FullRepoName)

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -77,7 +77,7 @@ func run(c *cobra.Command, _ []string) {
 		if forceFork {
 			fork = true
 		} else {
-			res, err := gh.IsPushable(logger.Writer(), repoDirPath)
+			res, err := gh.IsPushable(logger.Writer(), repo.FullRepoName)
 			if err != nil {
 				logger.Warnf("Unable to determine if we can push to %s: %s", orgDirPath, err)
 				fork = true

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -79,7 +79,7 @@ func run(c *cobra.Command, _ []string) {
 		} else {
 			res, err := gh.IsPushable(logger.Writer(), repo.FullRepoName)
 			if err != nil {
-				logger.Warnf("Unable to determine if we can push to %s: %s", orgDirPath, err)
+				logger.Warnf("Unable to determine if we can push to %s: %s", repo.FullRepoName, err)
 				fork = true
 			} else {
 				fork = !res

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -86,10 +86,10 @@ func run(c *cobra.Command, _ []string) {
 			}
 		}
 
-		if !fork {
-			cloneActivity = logger.StartActivity("Cloning %s into %s/%s", repo.FullRepoName, orgDirPath, repo.RepoName)
-		} else {
+		if fork {
 			cloneActivity = logger.StartActivity("Forking and cloning %s into %s/%s", repo.FullRepoName, orgDirPath, repo.RepoName)
+		} else {
+			cloneActivity = logger.StartActivity("Cloning %s into %s/%s", repo.FullRepoName, orgDirPath, repo.RepoName)
 		}
 
 		err := os.MkdirAll(orgDirPath, os.ModeDir|0o755)
@@ -106,10 +106,10 @@ func run(c *cobra.Command, _ []string) {
 			continue
 		}
 
-		if !fork {
-			err = gh.Clone(cloneActivity.Writer(), orgDirPath, repo.FullRepoName)
-		} else {
+		if fork {
 			err = gh.ForkAndClone(cloneActivity.Writer(), orgDirPath, repo.FullRepoName)
+		} else {
+			err = gh.Clone(cloneActivity.Writer(), orgDirPath, repo.FullRepoName)
 		}
 
 		if err != nil {

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -45,7 +45,7 @@ func NewCloneCmd() *cobra.Command {
 		Run:   run,
 	}
 
-	cmd.Flags().BoolVar(&forceFork, "fork", false, "Force forking, instead of turbolift attempting to branch push")
+	cmd.Flags().BoolVar(&forceFork, "fork", false, "Force forking, instead of turbolift choosing whether to fork/branch based on permissions")
 	cmd.Flags().StringVar(&repoFile, "repos", "repos.txt", "A file containing a list of repositories to clone.")
 
 	return cmd

--- a/cmd/clone/clone_test.go
+++ b/cmd/clone/clone_test.go
@@ -79,10 +79,10 @@ func TestItLogsCloneErrorsButContinuesToTryAll(t *testing.T) {
 	assert.Contains(t, out, "2 repos errored")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1"},
-		{"work/org", "org/repo1"},
-		{"work/org/repo2"},
-		{"work/org", "org/repo2"},
+		{"user_can_push", "work/org/repo1"},
+		{"clone", "work/org", "org/repo1"},
+		{"user_can_push", "work/org/repo2"},
+		{"clone", "work/org", "org/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{})
 }
@@ -103,8 +103,8 @@ func TestItLogsForkAndCloneErrorsButContinuesToTryAll(t *testing.T) {
 	assert.Contains(t, out, "2 repos errored")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org", "org/repo1"},
-		{"work/org", "org/repo2"},
+		{"fork_and_clone", "work/org", "org/repo1"},
+		{"fork_and_clone", "work/org", "org/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{})
 }
@@ -124,8 +124,8 @@ func TestItLogsCheckoutErrorsButContinuesToTryAll(t *testing.T) {
 	assert.Contains(t, out, "2 repos errored")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org", "org/repo1"},
-		{"work/org", "org/repo2"},
+		{"fork_and_clone", "work/org", "org/repo1"},
+		{"fork_and_clone", "work/org", "org/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{
 		{"checkout", "work/org/repo1", testsupport.Pwd()},
@@ -148,10 +148,10 @@ func TestItPullsFromUpstreamWhenCloningWithFork(t *testing.T) {
 	assert.Contains(t, out, "turbolift clone completed (2 repos cloned, 0 repos skipped)")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org1", "org1/repo1"},
-		{"work/org1/repo1", "org1/repo1"},
-		{"work/org2", "org2/repo2"},
-		{"work/org2/repo2", "org2/repo2"},
+		{"fork_and_clone", "work/org1", "org1/repo1"},
+		{"get_default_branch", "work/org1/repo1", "org1/repo1"},
+		{"fork_and_clone", "work/org2", "org2/repo2"},
+		{"get_default_branch", "work/org2/repo2", "org2/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{
 		{"checkout", "work/org1/repo1", testsupport.Pwd()},
@@ -187,11 +187,12 @@ func TestItDoesNotPullFromUpstreamWhenCloningWithoutFork(t *testing.T) {
 	assert.Contains(t, out, "turbolift clone completed (2 repos cloned, 0 repos skipped)")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org1/repo1"},
-		{"work/org1", "org1/repo1"},
-		{"work/org2/repo2"},
-		{"work/org2", "org2/repo2"},
+		{"user_can_push", "work/org1/repo1"},
+		{"clone", "work/org1", "org1/repo1"},
+		{"user_can_push", "work/org2/repo2"},
+		{"clone", "work/org2", "org2/repo2"},
 	})
+
 	fakeGit.AssertCalledWith(t, [][]string{
 		{"checkout", "work/org1/repo1", testsupport.Pwd()},
 		{"checkout", "work/org2/repo2", testsupport.Pwd()},
@@ -213,10 +214,10 @@ func TestItLogsDefaultBranchErrorsButContinuesToTryAll(t *testing.T) {
 	assert.Contains(t, out, "2 repos errored")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org1", "org1/repo1"},
-		{"work/org1/repo1", "org1/repo1"},
-		{"work/org2", "org2/repo2"},
-		{"work/org2/repo2", "org2/repo2"},
+		{"fork_and_clone", "work/org1", "org1/repo1"},
+		{"get_default_branch", "work/org1/repo1", "org1/repo1"},
+		{"fork_and_clone", "work/org2", "org2/repo2"},
+		{"get_default_branch", "work/org2/repo2", "org2/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{
 		{"checkout", "work/org1/repo1", testsupport.Pwd()},
@@ -241,10 +242,10 @@ func TestItLogsPullErrorsButContinuesToTryAll(t *testing.T) {
 	assert.Contains(t, out, "2 repos errored")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org1", "org1/repo1"},
-		{"work/org1/repo1", "org1/repo1"},
-		{"work/org2", "org2/repo2"},
-		{"work/org2/repo2", "org2/repo2"},
+		{"fork_and_clone", "work/org1", "org1/repo1"},
+		{"get_default_branch", "work/org1/repo1", "org1/repo1"},
+		{"fork_and_clone", "work/org2", "org2/repo2"},
+		{"get_default_branch", "work/org2/repo2", "org2/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{
 		{"checkout", "work/org1/repo1", testsupport.Pwd()},
@@ -268,10 +269,10 @@ func TestItClonesReposFoundInReposFile(t *testing.T) {
 	assert.Contains(t, out, "turbolift clone completed (2 repos cloned, 0 repos skipped)")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1"},
-		{"work/org", "org/repo1"},
-		{"work/org/repo2"},
-		{"work/org", "org/repo2"},
+		{"user_can_push", "work/org/repo1"},
+		{"clone", "work/org", "org/repo1"},
+		{"user_can_push", "work/org/repo2"},
+		{"clone", "work/org", "org/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{
 		{"checkout", "work/org/repo1", testsupport.Pwd()},
@@ -291,10 +292,10 @@ func TestItClonesReposInMultipleOrgs(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/orgA/repo1"},
-		{"work/orgA", "orgA/repo1"},
-		{"work/orgB/repo2"},
-		{"work/orgB", "orgB/repo2"},
+		{"user_can_push", "work/orgA/repo1"},
+		{"clone", "work/orgA", "orgA/repo1"},
+		{"user_can_push", "work/orgB/repo2"},
+		{"clone", "work/orgB", "orgB/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{
 		{"checkout", "work/orgA/repo1", testsupport.Pwd()},
@@ -314,10 +315,10 @@ func TestItClonesReposFromOtherHosts(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/orgA/repo1"},
-		{"work/orgA", "mygitserver.com/orgA/repo1"},
-		{"work/orgB/repo2"},
-		{"work/orgB", "orgB/repo2"},
+		{"user_can_push", "work/orgA/repo1"},
+		{"clone", "work/orgA", "mygitserver.com/orgA/repo1"},
+		{"user_can_push", "work/orgB/repo2"},
+		{"clone", "work/orgB", "orgB/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{
 		{"checkout", "work/orgA/repo1", testsupport.Pwd()},
@@ -339,10 +340,55 @@ func TestItSkipsCloningIfAWorkingCopyAlreadyExists(t *testing.T) {
 	assert.Contains(t, out, "Forking and cloning org/repo1")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org", "org/repo2"},
-		{"work/org/repo2", "org/repo2"},
+		{"fork_and_clone", "work/org", "org/repo2"},
+		{"get_default_branch", "work/org/repo2", "org/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{
+		{"checkout", "work/org/repo2", testsupport.Pwd()},
+		{"pull", "--ff-only", "work/org/repo2", "upstream", "main"},
+	})
+}
+
+func TestItForksIfUserHasNoPushPermission(t *testing.T) {
+	fakeGitHub := github.NewFakeGitHub(func(command github.Command, args []string) (bool, error) {
+		switch command {
+		case github.IsPushable:
+			return false, nil
+		case github.ForkAndClone:
+			return true, nil
+		case github.GetDefaultBranchName:
+			return true, nil
+		default:
+			return false, errors.New("unexpected command")
+		}
+	}, func(workingDir string) (interface{}, error) {
+		return nil, errors.New("unexpected call")
+	})
+
+	// fakeGitHub := github.NewAlwaysSucceedsFakeGitHub()
+	gh = fakeGitHub
+	fakeGit := git.NewAlwaysSucceedsFakeGit()
+	g = fakeGit
+
+	testsupport.PrepareTempCampaign(false, "org/repo1", "org/repo2")
+
+	out, err := runCloneCommand()
+	assert.NoError(t, err)
+	assert.Contains(t, out, "Forking and cloning org/repo1")
+	assert.Contains(t, out, "Forking and cloning org/repo2")
+	assert.Contains(t, out, "turbolift clone completed (2 repos cloned, 0 repos skipped)")
+
+	fakeGitHub.AssertCalledWith(t, [][]string{
+		{"user_can_push", "work/org/repo1"},
+		{"fork_and_clone", "work/org", "org/repo1"},
+		{"get_default_branch", "work/org/repo1", "org/repo1"},
+		{"user_can_push", "work/org/repo2"},
+		{"fork_and_clone", "work/org", "org/repo2"},
+		{"get_default_branch", "work/org/repo2", "org/repo2"},
+	})
+	fakeGit.AssertCalledWith(t, [][]string{
+		{"checkout", "work/org/repo1", testsupport.Pwd()},
+		{"pull", "--ff-only", "work/org/repo1", "upstream", "main"},
 		{"checkout", "work/org/repo2", testsupport.Pwd()},
 		{"pull", "--ff-only", "work/org/repo2", "upstream", "main"},
 	})

--- a/cmd/clone/clone_test.go
+++ b/cmd/clone/clone_test.go
@@ -79,9 +79,9 @@ func TestItLogsCloneErrorsButContinuesToTryAll(t *testing.T) {
 	assert.Contains(t, out, "2 repos errored")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"user_can_push", "work/org/repo1"},
+		{"user_can_push", "org/repo1"},
 		{"clone", "work/org", "org/repo1"},
-		{"user_can_push", "work/org/repo2"},
+		{"user_can_push", "org/repo2"},
 		{"clone", "work/org", "org/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{})
@@ -187,9 +187,9 @@ func TestItDoesNotPullFromUpstreamWhenCloningWithoutFork(t *testing.T) {
 	assert.Contains(t, out, "turbolift clone completed (2 repos cloned, 0 repos skipped)")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"user_can_push", "work/org1/repo1"},
+		{"user_can_push", "org1/repo1"},
 		{"clone", "work/org1", "org1/repo1"},
-		{"user_can_push", "work/org2/repo2"},
+		{"user_can_push", "org2/repo2"},
 		{"clone", "work/org2", "org2/repo2"},
 	})
 
@@ -269,9 +269,9 @@ func TestItClonesReposFoundInReposFile(t *testing.T) {
 	assert.Contains(t, out, "turbolift clone completed (2 repos cloned, 0 repos skipped)")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"user_can_push", "work/org/repo1"},
+		{"user_can_push", "org/repo1"},
 		{"clone", "work/org", "org/repo1"},
-		{"user_can_push", "work/org/repo2"},
+		{"user_can_push", "org/repo2"},
 		{"clone", "work/org", "org/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{
@@ -292,9 +292,9 @@ func TestItClonesReposInMultipleOrgs(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"user_can_push", "work/orgA/repo1"},
+		{"user_can_push", "orgA/repo1"},
 		{"clone", "work/orgA", "orgA/repo1"},
-		{"user_can_push", "work/orgB/repo2"},
+		{"user_can_push", "orgB/repo2"},
 		{"clone", "work/orgB", "orgB/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{
@@ -315,9 +315,9 @@ func TestItClonesReposFromOtherHosts(t *testing.T) {
 	assert.NoError(t, err)
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"user_can_push", "work/orgA/repo1"},
+		{"user_can_push", "mygitserver.com/orgA/repo1"},
 		{"clone", "work/orgA", "mygitserver.com/orgA/repo1"},
-		{"user_can_push", "work/orgB/repo2"},
+		{"user_can_push", "orgB/repo2"},
 		{"clone", "work/orgB", "orgB/repo2"},
 	})
 	fakeGit.AssertCalledWith(t, [][]string{
@@ -379,10 +379,10 @@ func TestItForksIfUserHasNoPushPermission(t *testing.T) {
 	assert.Contains(t, out, "turbolift clone completed (2 repos cloned, 0 repos skipped)")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"user_can_push", "work/org/repo1"},
+		{"user_can_push", "org/repo1"},
 		{"fork_and_clone", "work/org", "org/repo1"},
 		{"get_default_branch", "work/org/repo1", "org/repo1"},
-		{"user_can_push", "work/org/repo2"},
+		{"user_can_push", "org/repo2"},
 		{"fork_and_clone", "work/org", "org/repo2"},
 		{"get_default_branch", "work/org/repo2", "org/repo2"},
 	})

--- a/cmd/clone/clone_test.go
+++ b/cmd/clone/clone_test.go
@@ -64,7 +64,6 @@ func TestItLogsCloneErrorsButContinuesToTryAll(t *testing.T) {
 		return nil, errors.New("unexpected call")
 	})
 
-	// fakeGitHub := github.NewAlwaysFailsFakeGitHub()
 	gh = fakeGitHub
 	fakeGit := git.NewAlwaysFailsFakeGit()
 	g = fakeGit
@@ -173,7 +172,6 @@ func TestItDoesNotPullFromUpstreamWhenCloningWithoutFork(t *testing.T) {
 		return nil, errors.New("unexpected call")
 	})
 
-	// fakeGitHub := github.NewAlwaysSucceedsFakeGitHub()
 	gh = fakeGitHub
 	fakeGit := git.NewAlwaysSucceedsFakeGit()
 	g = fakeGit

--- a/cmd/create_prs/create_prs_test.go
+++ b/cmd/create_prs/create_prs_test.go
@@ -17,12 +17,14 @@ package create_prs
 
 import (
 	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/skyscanner/turbolift/internal/git"
 	"github.com/skyscanner/turbolift/internal/github"
 	"github.com/skyscanner/turbolift/internal/prompt"
 	"github.com/skyscanner/turbolift/internal/testsupport"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestItWarnsIfDescriptionFileTemplateIsUnchanged(t *testing.T) {
@@ -127,8 +129,8 @@ func TestItLogsCreatePrErrorsButContinuesToTryAll(t *testing.T) {
 	assert.Contains(t, out, "2 errored")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1", "PR title"},
-		{"work/org/repo2", "PR title"},
+		{"create_pull_request", "work/org/repo1", "PR title"},
+		{"create_pull_request", "work/org/repo2", "PR title"},
 	})
 }
 
@@ -148,8 +150,8 @@ func TestItLogsCreatePrSkippedButContinuesToTryAll(t *testing.T) {
 	assert.Contains(t, out, "0 OK, 2 skipped")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1", "PR title"},
-		{"work/org/repo2", "PR title"},
+		{"create_pull_request", "work/org/repo1", "PR title"},
+		{"create_pull_request", "work/org/repo2", "PR title"},
 	})
 }
 
@@ -167,8 +169,8 @@ func TestItLogsCreatePrsSucceeds(t *testing.T) {
 	assert.Contains(t, out, "2 OK, 0 skipped")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1", "PR title"},
-		{"work/org/repo2", "PR title"},
+		{"create_pull_request", "work/org/repo1", "PR title"},
+		{"create_pull_request", "work/org/repo2", "PR title"},
 	})
 }
 
@@ -188,8 +190,8 @@ func TestItLogsCreateDraftPr(t *testing.T) {
 	assert.Contains(t, out, "2 OK, 0 skipped")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1", "PR title"},
-		{"work/org/repo2", "PR title"},
+		{"create_pull_request", "work/org/repo1", "PR title"},
+		{"create_pull_request", "work/org/repo2", "PR title"},
 	})
 }
 
@@ -213,8 +215,8 @@ func TestItCreatesPrsFromAlternativeDescriptionFile(t *testing.T) {
 	assert.Contains(t, out, "2 OK, 0 skipped")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1", "custom PR title"},
-		{"work/org/repo2", "custom PR title"},
+		{"create_pull_request", "work/org/repo1", "custom PR title"},
+		{"create_pull_request", "work/org/repo2", "custom PR title"},
 	})
 }
 
@@ -223,7 +225,6 @@ func runCommand() (string, error) {
 	outBuffer := bytes.NewBufferString("")
 	cmd.SetOut(outBuffer)
 	err := cmd.Execute()
-
 	if err != nil {
 		return outBuffer.String(), err
 	}
@@ -236,7 +237,6 @@ func runCommandWithAlternativeDescriptionFile(fileName string) (string, error) {
 	outBuffer := bytes.NewBufferString("")
 	cmd.SetOut(outBuffer)
 	err := cmd.Execute()
-
 	if err != nil {
 		return outBuffer.String(), err
 	}
@@ -249,7 +249,6 @@ func runCommandDraft() (string, error) {
 	outBuffer := bytes.NewBufferString("")
 	cmd.SetOut(outBuffer)
 	err := cmd.Execute()
-
 	if err != nil {
 		return outBuffer.String(), err
 	}

--- a/cmd/updateprs/updateprs_test.go
+++ b/cmd/updateprs/updateprs_test.go
@@ -26,8 +26,8 @@ func TestItLogsClosePrErrorsButContinuesToTryAll(t *testing.T) {
 	assert.Contains(t, out, "2 errored")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1", filepath.Base(tempDir)},
-		{"work/org/repo2", filepath.Base(tempDir)},
+		{"close_pull_request", "work/org/repo1", filepath.Base(tempDir)},
+		{"close_pull_request", "work/org/repo2", filepath.Base(tempDir)},
 	})
 }
 
@@ -46,8 +46,8 @@ func TestItClosesPrsSuccessfully(t *testing.T) {
 	assert.NotContains(t, out, "error")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1", filepath.Base(tempDir)},
-		{"work/org/repo2", filepath.Base(tempDir)},
+		{"close_pull_request", "work/org/repo1", filepath.Base(tempDir)},
+		{"close_pull_request", "work/org/repo2", filepath.Base(tempDir)},
 	})
 }
 
@@ -65,8 +65,8 @@ func TestNoPRFound(t *testing.T) {
 	assert.Contains(t, out, "0 OK, 2 skipped")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1", filepath.Base(tempDir)},
-		{"work/org/repo2", filepath.Base(tempDir)},
+		{"close_pull_request", "work/org/repo1", filepath.Base(tempDir)},
+		{"close_pull_request", "work/org/repo2", filepath.Base(tempDir)},
 	})
 }
 
@@ -102,8 +102,8 @@ func TestItLogsUpdateDescriptionErrorsButContinuesToTryAll(t *testing.T) {
 	assert.Contains(t, out, "2 errored")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1", "PR title", "PR body"},
-		{"work/org/repo2", "PR title", "PR body"},
+		{"update_pr_description", "work/org/repo1", "PR title", "PR body"},
+		{"update_pr_description", "work/org/repo2", "PR title", "PR body"},
 	})
 }
 
@@ -122,8 +122,8 @@ func TestItUpdatesDescriptionsSuccessfully(t *testing.T) {
 	assert.Contains(t, out, "2 OK, 0 skipped")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1", "Updated PR title", "Updated PR body"},
-		{"work/org/repo2", "Updated PR title", "Updated PR body"},
+		{"update_pr_description", "work/org/repo1", "Updated PR title", "Updated PR body"},
+		{"update_pr_description", "work/org/repo2", "Updated PR title", "Updated PR body"},
 	})
 }
 
@@ -142,8 +142,8 @@ func TestItUpdatesDescriptionsFromAlternativeFile(t *testing.T) {
 	assert.Contains(t, out, "2 OK, 0 skipped")
 
 	fakeGitHub.AssertCalledWith(t, [][]string{
-		{"work/org/repo1", "custom PR title", "custom PR body"},
-		{"work/org/repo2", "custom PR title", "custom PR body"},
+		{"update_pr_description", "work/org/repo1", "custom PR title", "custom PR body"},
+		{"update_pr_description", "work/org/repo2", "custom PR title", "custom PR body"},
 	})
 }
 

--- a/internal/github/fake_github.go
+++ b/internal/github/fake_github.go
@@ -42,40 +42,40 @@ type FakeGitHub struct {
 }
 
 func (f *FakeGitHub) CreatePullRequest(_ io.Writer, workingDir string, metadata PullRequest) (didCreate bool, err error) {
-	args := []string{workingDir, metadata.Title}
+	args := []string{"create_pull_request", workingDir, metadata.Title}
 	f.calls = append(f.calls, args)
 	return f.handler(CreatePullRequest, args)
 }
 
 func (f *FakeGitHub) ForkAndClone(_ io.Writer, workingDir string, fullRepoName string) error {
-	args := []string{workingDir, fullRepoName}
+	args := []string{"fork_and_clone", workingDir, fullRepoName}
 	f.calls = append(f.calls, args)
 	_, err := f.handler(ForkAndClone, args)
 	return err
 }
 
 func (f *FakeGitHub) Clone(_ io.Writer, workingDir string, fullRepoName string) error {
-	args := []string{workingDir, fullRepoName}
+	args := []string{"clone", workingDir, fullRepoName}
 	f.calls = append(f.calls, args)
 	_, err := f.handler(Clone, args)
 	return err
 }
 
 func (f *FakeGitHub) IsPushable(_ io.Writer, repoDir string) (bool, error) {
-	args := []string{repoDir}
+	args := []string{"user_can_push", repoDir}
 	f.calls = append(f.calls, args)
 	return f.handler(IsPushable, args)
 }
 
 func (f *FakeGitHub) ClosePullRequest(_ io.Writer, workingDir string, branchName string) error {
-	args := []string{workingDir, branchName}
+	args := []string{"close_pull_request", workingDir, branchName}
 	f.calls = append(f.calls, args)
 	_, err := f.handler(ClosePullRequest, args)
 	return err
 }
 
 func (f *FakeGitHub) GetPR(_ io.Writer, workingDir string, _ string) (*PrStatus, error) {
-	f.calls = append(f.calls, []string{workingDir})
+	f.calls = append(f.calls, []string{"get_pr", workingDir})
 	result, err := f.returningHandler(workingDir)
 	if result == nil {
 		return nil, err
@@ -84,14 +84,14 @@ func (f *FakeGitHub) GetPR(_ io.Writer, workingDir string, _ string) (*PrStatus,
 }
 
 func (f *FakeGitHub) GetDefaultBranchName(_ io.Writer, workingDir string, fullRepoName string) (string, error) {
-	args := []string{workingDir, fullRepoName}
+	args := []string{"get_default_branch", workingDir, fullRepoName}
 	f.calls = append(f.calls, args)
 	_, err := f.handler(GetDefaultBranchName, args)
 	return "main", err
 }
 
 func (f *FakeGitHub) UpdatePRDescription(_ io.Writer, workingDir string, title string, body string) error {
-	args := []string{workingDir, title, body}
+	args := []string{"update_pr_description", workingDir, title, body}
 	f.calls = append(f.calls, args)
 	_, err := f.handler(UpdatePRDescription, args)
 	return err
@@ -127,7 +127,7 @@ func NewAlwaysFailsFakeGitHub() *FakeGitHub {
 
 func NewAlwaysThrowNoPRFound() *FakeGitHub {
 	return NewFakeGitHub(func(command Command, args []string) (bool, error) {
-		workingDir, branchName := args[0], args[1]
+		workingDir, branchName := args[1], args[2]
 		return false, &NoPRFoundError{Path: workingDir, BranchName: branchName}
 	}, func(workingDir string) (interface{}, error) {
 		panic("should not be invoked")

--- a/internal/github/fake_github.go
+++ b/internal/github/fake_github.go
@@ -17,10 +17,23 @@ package github
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+)
+
+type Command int
+
+const (
+	ForkAndClone Command = iota
+	Clone
+	CreatePullRequest
+	ClosePullRequest
+	GetDefaultBranchName
+	UpdatePRDescription
+	IsPushable
 )
 
 type FakeGitHub struct {
@@ -47,6 +60,12 @@ func (f *FakeGitHub) Clone(_ io.Writer, workingDir string, fullRepoName string) 
 	f.calls = append(f.calls, args)
 	_, err := f.handler(Clone, args)
 	return err
+}
+
+func (f *FakeGitHub) IsPushable(_ io.Writer, repoDir string) (bool, error) {
+	args := []string{repoDir}
+	f.calls = append(f.calls, args)
+	return f.handler(IsPushable, args)
 }
 
 func (f *FakeGitHub) ClosePullRequest(_ io.Writer, workingDir string, branchName string) error {
@@ -134,14 +153,3 @@ func NewAlwaysFailsOnGetDefaultBranchFakeGitHub() *FakeGitHub {
 		return PrStatus{}, nil
 	})
 }
-
-type Command int
-
-const (
-	ForkAndClone Command = iota
-	Clone
-	CreatePullRequest
-	ClosePullRequest
-	GetDefaultBranchName
-	UpdatePRDescription
-)

--- a/internal/github/fake_github.go
+++ b/internal/github/fake_github.go
@@ -61,8 +61,8 @@ func (f *FakeGitHub) Clone(_ io.Writer, workingDir string, fullRepoName string) 
 	return err
 }
 
-func (f *FakeGitHub) IsPushable(_ io.Writer, repoDir string) (bool, error) {
-	args := []string{"user_can_push", repoDir}
+func (f *FakeGitHub) IsPushable(_ io.Writer, repo string) (bool, error) {
+	args := []string{"user_can_push", repo}
 	f.calls = append(f.calls, args)
 	return f.handler(IsPushable, args)
 }

--- a/internal/github/fake_github.go
+++ b/internal/github/fake_github.go
@@ -17,7 +17,6 @@ package github
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"testing"
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -170,6 +170,15 @@ func (r *RealGitHub) GetPR(output io.Writer, workingDir string, branchName strin
 	return nil, &NoPRFoundError{Path: workingDir, BranchName: branchName}
 }
 
+func (r *RealGitHub) IsPushable(output io.Writer, workingDir string, fullRepoName string) (bool, error) {
+	s, err := execInstance.ExecuteAndCapture(output, workingDir, "gh", "repo", "view", fullRepoName, "--json", "viewerPermission")
+	if err != nil {
+		return false, err
+	}
+
+	return IsPushable(s)
+}
+
 func NewRealGitHub() *RealGitHub {
 	return &RealGitHub{}
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -42,6 +42,7 @@ type GitHub interface {
 	UpdatePRDescription(output io.Writer, workingDir string, title string, body string) error
 	GetPR(output io.Writer, workingDir string, branchName string) (*PrStatus, error)
 	GetDefaultBranchName(output io.Writer, workingDir string, fullRepoName string) (string, error)
+	IsPushable(output io.Writer, repoDir string) (bool, error)
 }
 
 type RealGitHub struct{}
@@ -170,13 +171,13 @@ func (r *RealGitHub) GetPR(output io.Writer, workingDir string, branchName strin
 	return nil, &NoPRFoundError{Path: workingDir, BranchName: branchName}
 }
 
-func (r *RealGitHub) IsPushable(output io.Writer, workingDir string, fullRepoName string) (bool, error) {
-	s, err := execInstance.ExecuteAndCapture(output, workingDir, "gh", "repo", "view", fullRepoName, "--json", "viewerPermission")
+func (r *RealGitHub) IsPushable(output io.Writer, repoDir string) (bool, error) {
+	s, err := execInstance.ExecuteAndCapture(output, repoDir, "gh", "repo", "view", "--json", "viewerPermission")
 	if err != nil {
 		return false, err
 	}
 
-	return IsPushable(s)
+	return userHasPushPermission(s)
 }
 
 func NewRealGitHub() *RealGitHub {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -17,10 +17,12 @@ package github
 
 import (
 	"errors"
-	"github.com/skyscanner/turbolift/internal/executor"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/skyscanner/turbolift/internal/executor"
 )
 
 func TestItReturnsErrorOnFailedFork(t *testing.T) {

--- a/internal/github/util.go
+++ b/internal/github/util.go
@@ -26,7 +26,7 @@ type ViewerPermission struct {
 // IsPushable checks the output of the viewerPermission API query
 // and returns true if the user has write, maintain or admin permissions
 
-func IsPushable(viewerPermissionOutput string) (bool, error) {
+func userHasPushPermission(viewerPermissionOutput string) (bool, error) {
 	var vp ViewerPermission
 
 	if err := json.Unmarshal([]byte(viewerPermissionOutput), &vp); err != nil {

--- a/internal/github/util.go
+++ b/internal/github/util.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 Skyscanner Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// util contains helper functions needed for both real and fake implementations of the GitHub interface
+
+package github
+
+import "encoding/json"
+
+type ViewerPermission struct {
+	ViewerPermission string `json:"viewerPermission"`
+}
+
+// IsPushable checks the output of the viewerPermission API query
+// and returns true if the user has write, maintain or admin permissions
+
+func IsPushable(viewerPermissionOutput string) (bool, error) {
+	var vp ViewerPermission
+
+	if err := json.Unmarshal([]byte(viewerPermissionOutput), &vp); err != nil {
+		return false, err
+	}
+
+	switch vp.ViewerPermission {
+	case "WRITE", "MAINTAIN", "ADMIN":
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/internal/github/util_test.go
+++ b/internal/github/util_test.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Skyscanner Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package github
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPushableReturnsTrueForAllCases(t *testing.T) {
+	testCases := []string{
+		`{"viewerPermission":"WRITE"}`,
+		`{"viewerPermission":"MAINTAIN"}`,
+		`{"viewerPermission":"ADMIN"}`,
+	}
+
+	for _, testCase := range testCases {
+		pushable, err := IsPushable(testCase)
+		assert.NoError(t, err)
+		assert.True(t, pushable)
+	}
+}
+
+func TestIsPushableReturnsFalseForUnknownPermission(t *testing.T) {
+	testCases := []string{
+		`{"viewerPermission":"UNKNOWN"}`,
+		`{"viewerPermission":"READ"}`,
+		`{"viewerPermission":"RANDOM"}`,
+		`{"viewerPermission":""}`,
+	}
+
+	for _, testCase := range testCases {
+		pushable, err := IsPushable(testCase)
+		assert.NoError(t, err)
+		assert.False(t, pushable)
+	}
+}
+
+func TestIsPushableReturnsErrorForInvalidJSON(t *testing.T) {
+	testCases := []string{
+		`{"anotherParam":"WRITE"`,     // valid JSON but not the expected format
+		`{"viewerPermission":"WRITE"`, // invalid JSON
+		`viewerPermission: WRITE`,     // invalid JSON
+		`{"viewerPermission": WRITE}`, // invalid JSON
+	}
+
+	for _, testCase := range testCases {
+		_, err := IsPushable(testCase)
+		assert.Error(t, err)
+	}
+}

--- a/internal/github/util_test.go
+++ b/internal/github/util_test.go
@@ -41,6 +41,7 @@ func TestIsPushableReturnsFalseForUnknownPermission(t *testing.T) {
 		`{"viewerPermission":"READ"}`,
 		`{"viewerPermission":"RANDOM"}`,
 		`{"viewerPermission":""}`,
+		`{"anotherParam":"WRITE"}`, // valid JSON but not the expected format
 	}
 
 	for _, testCase := range testCases {
@@ -52,7 +53,6 @@ func TestIsPushableReturnsFalseForUnknownPermission(t *testing.T) {
 
 func TestIsPushableReturnsErrorForInvalidJSON(t *testing.T) {
 	testCases := []string{
-		`{"anotherParam":"WRITE"`,     // valid JSON but not the expected format
 		`{"viewerPermission":"WRITE"`, // invalid JSON
 		`viewerPermission: WRITE`,     // invalid JSON
 		`{"viewerPermission": WRITE}`, // invalid JSON

--- a/internal/github/util_test.go
+++ b/internal/github/util_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsPushableReturnsTrueForAllCases(t *testing.T) {
+func TestuserHasPushPermissionReturnsTrueForAllCases(t *testing.T) {
 	testCases := []string{
 		`{"viewerPermission":"WRITE"}`,
 		`{"viewerPermission":"MAINTAIN"}`,
@@ -29,13 +29,13 @@ func TestIsPushableReturnsTrueForAllCases(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pushable, err := IsPushable(testCase)
+		pushable, err := userHasPushPermission(testCase)
 		assert.NoError(t, err)
 		assert.True(t, pushable)
 	}
 }
 
-func TestIsPushableReturnsFalseForUnknownPermission(t *testing.T) {
+func TestuserHasPushPermissionReturnsFalseForUnknownPermission(t *testing.T) {
 	testCases := []string{
 		`{"viewerPermission":"UNKNOWN"}`,
 		`{"viewerPermission":"READ"}`,
@@ -45,13 +45,13 @@ func TestIsPushableReturnsFalseForUnknownPermission(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pushable, err := IsPushable(testCase)
+		pushable, err := userHasPushPermission(testCase)
 		assert.NoError(t, err)
 		assert.False(t, pushable)
 	}
 }
 
-func TestIsPushableReturnsErrorForInvalidJSON(t *testing.T) {
+func TestuserHasPushPermissionReturnsErrorForInvalidJSON(t *testing.T) {
 	testCases := []string{
 		`{"viewerPermission":"WRITE"`, // invalid JSON
 		`viewerPermission: WRITE`,     // invalid JSON
@@ -59,7 +59,7 @@ func TestIsPushableReturnsErrorForInvalidJSON(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		_, err := IsPushable(testCase)
+		_, err := userHasPushPermission(testCase)
 		assert.Error(t, err)
 	}
 }


### PR DESCRIPTION
# Description of the change

## BREAKING CHANGE

- Deprecation of the `--no-fork` flag in favour of `--fork` to force forking.
- Default behaviour is branching if the user has permission to do so, otherwise turbolift will fork the repository.
- Unit tests for GH mocks include the type of calls it makes in the argument list.

## Context

The all-or-nothing approach of Turbolift around the clone policy (either forking or branching) is causing a lot of friction and requires the user to think about it.
`gh` goes around the problem by cloning normally but checking at push time whether the user has write permission on the target repository and prompt the user what to do.

We use a similar mechanism to decide _at clone time_ what the clone policy should be, branching or forking.
The user still has the option to force the forking if they desire.

## Change content

- Introduced the new forking policy and changed tests around that.
- Added a new unit test specifically for no write access
- Refactored testing to have more clarity on what calls are made to GH
- Changed documentation

## Related to

Fixes #146.
