### PR TITLE
fix(create_prs): Fix race condition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,4 @@ jobs:
           go-version: ^1.16
 
       - name: Run tests
-        run: go test ./...
-
+        run: make test

--- a/cmd/create_prs/create_prs.go
+++ b/cmd/create_prs/create_prs.go
@@ -17,11 +17,12 @@ package create_prs
 
 import (
 	"fmt"
-	"github.com/skyscanner/turbolift/internal/prompt"
 	"os"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/skyscanner/turbolift/internal/prompt"
 
 	"github.com/spf13/cobra"
 
@@ -72,12 +73,14 @@ func run(c *cobra.Command, _ []string) {
 		readCampaignActivity.EndWithFailure(err)
 		return
 	}
+	readCampaignActivity.EndWithSuccess()
+
+	// checking whether the description has changed
 	if prDescriptionUnchanged(dir) {
 		if !p.AskConfirm(fmt.Sprintf("It looks like the PR title and/or description may not have been updated in %s. Are you sure you want to proceed?", prDescriptionFile)) {
 			return
 		}
 	}
-	readCampaignActivity.EndWithSuccess()
 
 	doneCount := 0
 	skippedCount := 0

--- a/cmd/create_prs/create_prs_test.go
+++ b/cmd/create_prs/create_prs_test.go
@@ -225,10 +225,7 @@ func runCommand() (string, error) {
 	outBuffer := bytes.NewBufferString("")
 	cmd.SetOut(outBuffer)
 	err := cmd.Execute()
-	if err != nil {
-		return outBuffer.String(), err
-	}
-	return outBuffer.String(), nil
+	return outBuffer.String(), err
 }
 
 func runCommandWithAlternativeDescriptionFile(fileName string) (string, error) {
@@ -237,10 +234,7 @@ func runCommandWithAlternativeDescriptionFile(fileName string) (string, error) {
 	outBuffer := bytes.NewBufferString("")
 	cmd.SetOut(outBuffer)
 	err := cmd.Execute()
-	if err != nil {
-		return outBuffer.String(), err
-	}
-	return outBuffer.String(), nil
+	return outBuffer.String(), err
 }
 
 func runCommandDraft() (string, error) {
@@ -249,8 +243,5 @@ func runCommandDraft() (string, error) {
 	outBuffer := bytes.NewBufferString("")
 	cmd.SetOut(outBuffer)
 	err := cmd.Execute()
-	if err != nil {
-		return outBuffer.String(), err
-	}
-	return outBuffer.String(), nil
+	return outBuffer.String(), err
 }


### PR DESCRIPTION
# Description of change

- Moved `readCampaignActivity.EndWithSuccess()` to the correct position
  Having the activity end after the Prompt means the spinner creates
  a race condition.

- Simplified error handling in `runCommand` functions by returning the
  error directly.

- changed CI to run `make test` instead of its own go test version

# Relates to

- Relates to #145
- Fixes #149
