### PR TITLE
feat(create_prs): sleep at the end

### DIFF
--- a/cmd/create_prs/create_prs.go
+++ b/cmd/create_prs/create_prs.go
@@ -86,11 +86,6 @@ func run(c *cobra.Command, _ []string) {
 	skippedCount := 0
 	errorCount := 0
 	for _, repo := range dir.Repos {
-		if sleep > 0 {
-			logger.Successf("Sleeping for %s", sleep)
-			time.Sleep(sleep)
-		}
-
 		repoDirPath := path.Join("work", repo.OrgName, repo.RepoName) // i.e. work/org/repo
 
 		pushActivity := logger.StartActivity("Pushing changes in %s to origin", repo.FullRepoName)
@@ -134,6 +129,11 @@ func run(c *cobra.Command, _ []string) {
 		} else {
 			createPrActivity.EndWithSuccess()
 			doneCount++
+		}
+
+		if sleep > 0 {
+			logger.Successf("Sleeping for %s", sleep)
+			time.Sleep(sleep)
 		}
 	}
 

--- a/cmd/create_prs/create_prs.go
+++ b/cmd/create_prs/create_prs.go
@@ -85,7 +85,12 @@ func run(c *cobra.Command, _ []string) {
 	doneCount := 0
 	skippedCount := 0
 	errorCount := 0
-	for _, repo := range dir.Repos {
+	for i, repo := range dir.Repos {
+		if i > 0 && sleep > 0 {
+			logger.Successf("Sleeping for %s", sleep)
+			time.Sleep(sleep)
+		}
+
 		repoDirPath := path.Join("work", repo.OrgName, repo.RepoName) // i.e. work/org/repo
 
 		pushActivity := logger.StartActivity("Pushing changes in %s to origin", repo.FullRepoName)
@@ -129,11 +134,6 @@ func run(c *cobra.Command, _ []string) {
 		} else {
 			createPrActivity.EndWithSuccess()
 			doneCount++
-		}
-
-		if sleep > 0 {
-			logger.Successf("Sleeping for %s", sleep)
-			time.Sleep(sleep)
 		}
 	}
 


### PR DESCRIPTION
# Reasoning
Currently, when creating PRs with sleep, the procedure starts with the sleep.
This is not optimal, eg. it's possible that after waiting for a certain amount of time the user will be presented with an error.
```
➜  turbolift create-prs --sleep 30s
  OK   Reading campaign data (repos.txt, README.md)
  OK   Sleeping for 30s
 FAIL  Pushing changes in leszekbulawa/myrepo to origin: exit status 128
```

# Description of change
Moved sleep to the end of create_prs function.

Before (starts with the sleep):
```
turbolift create-prs --sleep 30s 
  OK   Reading campaign data (repos.txt, README.md)
  OK   Sleeping for 30s
 WARN  Pushing changes in me/non-existing-repo to origin: Directory work/me/non-existing-repo does not exist - has it been cloned?

  OK   turbolift create-prs completed (0 OK, 1 skipped)
```
After:
```
 ~/dev/turbolift/turbolift create-prs --sleep 30s
  OK   Reading campaign data (repos.txt, README.md)
 WARN  Pushing changes in me/non-existing-repo to origin: Directory work/me/non-existing-repo does not exist - has it been cloned?

  OK   turbolift create-prs completed (0 OK, 1 skipped)
```