### PR TITLE
SDPLAT-26671: use GH_APP for GitHub REST API

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,12 +44,7 @@ jobs:
       #   https://support.github.com/ticket/enterprise/3427/3214517
       - name: Prepare CodeQL Results
         run: |
-          gzip -c ../results/go.sarif | base64 -w0 > ./codeql-results.sarif.gz.b64
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: codeql
-          path: codeql-results.sarif.gz.b64
+          echo "SARIF_RESULTS=$(gzip -c ../results/go.sarif | base64 -w0)" >> $GITHUB_ENV
 
       # Workaround for parallel GitHub bugs
       # * Can't use GHA token with IP allowlisting
@@ -62,5 +57,5 @@ jobs:
             -X POST \
             -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "$(cat ./codeql-results.sarif.gz.b64)"}' \
+            -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "${{ env.SARIF_RESULTS }}"}' \
             https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,4 +49,5 @@ jobs:
           curl -X POST \
             -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "$(cat ../codeql-results.sarif.gz.b64)"}' \    https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs
+            -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "$(cat ../codeql-results.sarif.gz.b64)"}' \
+            https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,3 +35,19 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           token: ${{ steps.app-token.outputs.token }}
+          upload: never
+
+      # Workaround for parallel GitHub bugs
+      # * Can't use GHA token with IP allowlisting
+      #   https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#using-github-actions-with-an-ip-allow-list
+      # * Can't use codeql-action/analyze with custom token
+      #   https://support.github.com/ticket/enterprise/3427/3214517
+      - name: Upload CodeQL Results
+        run: |
+          gzip -c ../results/go.sarif | base64 -w0 > ../codeql-results.sarif.gz.b64
+
+          curl -X POST \
+            -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            -d @../codeql-results.sarif.gz.b64 \
+            https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,5 +49,4 @@ jobs:
           curl -X POST \
             -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            -d @../codeql-results.sarif.gz.b64 \
-            https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs
+            -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "$(cat ../codeql-results.sarif.gz.b64)"}' \    https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,19 +16,20 @@ jobs:
         with:
           go-version: ^1.23
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: go
-
-      - name: Build
-        run: make build
-
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Build
+        run: make build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,7 @@ name: CodeQL
 on:
   pull_request:
   schedule:
-    - cron: '09 09 * * 1'
+    - cron: "09 09 * * 1"
 
 jobs:
   codeql:
@@ -24,5 +24,13 @@ jobs:
       - name: Build
         run: make build
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,6 @@
 ---
 name: CodeQL
 on:
-  pull_request:
   schedule:
     - cron: "09 09 * * 1"
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,10 +37,19 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           upload: never
 
+      # Workaround for parallel GitHub bugs
+      # * Can't use GHA token with IP allowlisting
+      #   https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#using-github-actions-with-an-ip-allow-list
+      # * Can't use codeql-action/analyze with custom token
+      #   https://support.github.com/ticket/enterprise/3427/3214517
+      - name: Prepare CodeQL Results
+        run: |
+          gzip -c ../results/go.sarif | base64 -w0 > ./codeql-results.sarif.gz.b64
+
       - uses: actions/upload-artifact@v4
         with:
           name: codeql
-          path: ../results/go.sarif
+          path: codeql-results.sarif.gz.b64
 
       # Workaround for parallel GitHub bugs
       # * Can't use GHA token with IP allowlisting
@@ -49,9 +58,8 @@ jobs:
       #   https://support.github.com/ticket/enterprise/3427/3214517
       - name: Upload CodeQL Results
         run: |
-          gzip -c ../results/go.sarif | base64 -w0 > ../codeql-results.sarif.gz.b64
-
-          curl -X POST \
+          curl --fail-with-body \
+            -X POST \
             -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
             -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "$(cat ./codeql-results.sarif.gz.b64)"}' \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,10 +44,8 @@ jobs:
       #   https://support.github.com/ticket/enterprise/3427/3214517
       - name: Upload CodeQL Results
         run: |
-          gzip -c ../results/go.sarif | base64 -w0 > ../codeql-results.sarif.gz.b64
-
           curl -X POST \
             -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "$(cat ../codeql-results.sarif.gz.b64)"}' \
+            -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "$(cat ../results/go.sarif)"}' \
             https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,11 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           upload: never
 
+      - uses: actions/upload-artifact@v4
+        with:
+          name: codeql
+          path: ../results/go.sarif
+
       # Workaround for parallel GitHub bugs
       # * Can't use GHA token with IP allowlisting
       #   https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#using-github-actions-with-an-ip-allow-list
@@ -44,8 +49,10 @@ jobs:
       #   https://support.github.com/ticket/enterprise/3427/3214517
       - name: Upload CodeQL Results
         run: |
+          gzip -c ../results/go.sarif | base64 -w0 > ../codeql-results.sarif.gz.b64
+
           curl -X POST \
             -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "$(cat ../results/go.sarif)"}' \
+            -d '{"commit_sha": "${{ github.sha }}", "ref": "${{ github.ref }}", "sarif": "$(cat ./codeql-results.sarif.gz.b64)"}' \
             https://api.github.com/repos/${{ github.repository }}/code-scanning/sarifs

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,12 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,16 @@ jobs:
         with:
           go-version: ^1.23
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v6.1.0
         with:
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
Use a GitHub App for access to the GitHub REST API as a workaround for [limitations with IP allowlisting](https://docs.github.com/en/enterprise-cloud@latest/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/managing-allowed-ip-addresses-for-your-organization#using-github-actions-with-an-ip-allow-list).