### PR TITLE
fix(clone): update turbolift foreach log message

### DIFF
--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -160,7 +160,7 @@ func run(c *cobra.Command, _ []string) {
 	}
 	logger.Println("To continue:")
 	logger.Println("\t1. Make your changes in the cloned repositories within the", colors.Cyan("work"), "directory")
-	logger.Println("\t2. Add new files across all repos using", colors.Cyan(`turbolift foreach git add -A`))
+	logger.Println("\t2. Add new files across all repos using", colors.Cyan(`turbolift foreach -- git add -A`))
 	logger.Println("\t3. Commit changes across all repos using", colors.Cyan(`turbolift commit --message "Your commit message"`))
 	logger.Println("\t4. Change the PR title and description in the", colors.Cyan(`README.md`), "of a campaign")
 }


### PR DESCRIPTION
Super minor but it caught me out when I was trying this tool out for the first time. The command in the log message will result in an error message if you try to run it: `Error: unknown shorthand flag: 'A' in -A`

This PR:

- Updates the log message to include the correct command