### PR TITLE
Don't run release drafter for PRs from forks

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request && github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token


### PR DESCRIPTION
Because `secrets.GH_APP_PRIVATE_KEY` cannot be resolved on a fork PR, and thus the workflow inevitably fails.

A PR from a fork will still execute release drafter at merge time (the `push` event to `main`).