### PR TITLE
Add tests for validateFlags

### DIFF
--- a/cmd/updateprs/updateprs_test.go
+++ b/cmd/updateprs/updateprs_test.go
@@ -13,6 +13,23 @@ import (
 	"github.com/skyscanner/turbolift/internal/testsupport"
 )
 
+func TestValidateFlagsNoneSet(t *testing.T) {
+	err := validateFlags(false, false, false)
+	assert.Error(t, err)
+	assert.Equal(t, "update-prs needs one and only one action flag", err.Error())
+}
+
+func TestValidateFlagsMultipleSet(t *testing.T) {
+	err := validateFlags(true, false, true)
+	assert.Error(t, err)
+	assert.Equal(t, "update-prs needs one and only one action flag", err.Error())
+}
+
+func TestValidateFlagsSingleSet(t *testing.T) {
+	err := validateFlags(true, false, false)
+	assert.NoError(t, err)
+}
+
 func TestItLogsClosePrErrorsButContinuesToTryAll(t *testing.T) {
 	fakeGitHub := github.NewAlwaysFailsFakeGitHub()
 	gh = fakeGitHub


### PR DESCRIPTION
## Summary
- cover validateFlags logic with new tests in `updateprs_test.go`

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*

------
https://chatgpt.com/codex/tasks/task_b_685ab5d822c0832eb9e57ec494c4f078