### PR TITLE
Fix file closing and lint issues

### DIFF
--- a/cmd/foreach/foreach.go
+++ b/cmd/foreach/foreach.go
@@ -185,16 +185,8 @@ func setupOutputFiles(campaignName string, command string, logger *logging.Logge
 	// create the files
 	successfulReposFile, _ := os.Create(successfulReposFileName)
 	failedReposFile, _ := os.Create(failedReposFileName)
-	defer func() {
-		if err := successfulReposFile.Close(); err != nil {
-			logger.Warnf("Failed to close successfulReposFile: %v", err)
-		}
-	}()
-	defer func() {
-		if err := failedReposFile.Close(); err != nil {
-			logger.Warnf("Failed to close failedReposFile: %v", err)
-		}
-	}()
+	defer closeWithWarning(successfulReposFile, "successfulReposFile", logger)
+	defer closeWithWarning(failedReposFile, "failedReposFile", logger)
 
 	// create symlink to the results
 	if _, err := os.Lstat(previousResultsSymlink); err == nil {
@@ -215,11 +207,7 @@ func setupOutputFiles(campaignName string, command string, logger *logging.Logge
 func emitOutcomeToFiles(repo campaign.Repo, reposFileName string, logsDirectoryParent string, executionLogs string, logger *logging.Logger) {
 	// write the repo name to the repos file
 	reposFile, _ := os.OpenFile(reposFileName, os.O_RDWR|os.O_APPEND, 0644)
-	defer func() {
-		if err := reposFile.Close(); err != nil {
-			logger.Warnf("Failed to close reposFile: %v", err)
-		}
-	}()
+	defer closeWithWarning(reposFile, "reposFile", logger)
 	_, err := reposFile.WriteString(repo.FullRepoName + "\n")
 	if err != nil {
 		logger.Errorf("Failed to write repo name to %s: %s", reposFile.Name(), err)
@@ -234,11 +222,7 @@ func emitOutcomeToFiles(repo campaign.Repo, reposFileName string, logsDirectoryP
 	}
 
 	logs, _ := os.Create(logsFile)
-	defer func() {
-		if err := logs.Close(); err != nil {
-			logger.Warnf("Failed to close logs: %v", err)
-		}
-	}()
+	defer closeWithWarning(logs, "logs", logger)
 	_, err = logs.WriteString(executionLogs)
 	if err != nil {
 		logger.Errorf("Failed to write logs to %s: %s", logsFile, err)

--- a/cmd/foreach/foreach_test.go
+++ b/cmd/foreach/foreach_test.go
@@ -215,7 +215,11 @@ func TestItRunsAgainstSuccessfulReposOnly(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error setting up symlink: %s", err)
 	}
-	defer os.RemoveAll("mock_output")
+	defer func() {
+		if err := os.RemoveAll("mock_output"); err != nil {
+			t.Logf("Failed to remove mock_output: %v", err)
+		}
+	}()
 
 	out, err := runCommandReposSuccessful("--", "some", "command")
 	assert.NoError(t, err)
@@ -240,7 +244,11 @@ func TestItRunsAgainstFailedReposOnly(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error setting up symlink: %s", err)
 	}
-	defer os.RemoveAll("mock_output")
+	defer func() {
+		if err := os.RemoveAll("mock_output"); err != nil {
+			t.Logf("Failed to remove mock_output: %v", err)
+		}
+	}()
 
 	out, err := runCommandReposFailed("--", "some", "command")
 	assert.NoError(t, err)

--- a/cmd/foreach/helpers.go
+++ b/cmd/foreach/helpers.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Skyscanner Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package foreach
+
+import (
+	"io"
+
+	"github.com/skyscanner/turbolift/internal/logging"
+)
+
+func closeWithWarning(c io.Closer, name string, logger *logging.Logger) {
+	if err := c.Close(); err != nil {
+		logger.Warnf("Failed to close %s: %v", name, err)
+	}
+}

--- a/cmd/init/init_test.go
+++ b/cmd/init/init_test.go
@@ -18,7 +18,7 @@ package init
 import (
 	"github.com/skyscanner/turbolift/internal/testsupport"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -38,7 +38,7 @@ func TestTemplatedFilesHaveExpectedContent(t *testing.T) {
 	testsupport.CreateAndEnterTempDirectory()
 	runCommand()
 
-	readmeContents, err := ioutil.ReadFile("foo/README.md")
+	readmeContents, err := os.ReadFile("foo/README.md")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/github/util_test.go
+++ b/internal/github/util_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestuserHasPushPermissionReturnsTrueForAllCases(t *testing.T) {
+func TestUserHasPushPermissionReturnsTrueForAllCases(t *testing.T) {
 	testCases := []string{
 		`{"viewerPermission":"WRITE"}`,
 		`{"viewerPermission":"MAINTAIN"}`,
@@ -35,7 +35,7 @@ func TestuserHasPushPermissionReturnsTrueForAllCases(t *testing.T) {
 	}
 }
 
-func TestuserHasPushPermissionReturnsFalseForUnknownPermission(t *testing.T) {
+func TestUserHasPushPermissionReturnsFalseForUnknownPermission(t *testing.T) {
 	testCases := []string{
 		`{"viewerPermission":"UNKNOWN"}`,
 		`{"viewerPermission":"READ"}`,
@@ -51,7 +51,7 @@ func TestuserHasPushPermissionReturnsFalseForUnknownPermission(t *testing.T) {
 	}
 }
 
-func TestuserHasPushPermissionReturnsErrorForInvalidJSON(t *testing.T) {
+func TestUserHasPushPermissionReturnsErrorForInvalidJSON(t *testing.T) {
 	testCases := []string{
 		`{"viewerPermission":"WRITE"`, // invalid JSON
 		`viewerPermission: WRITE`,     // invalid JSON


### PR DESCRIPTION
## Summary
- check errors when closing files in foreach
- log errors on cleanup of mock output directories in tests
- rename GitHub permission test functions
- replace deprecated `ioutil.ReadFile` usage
- lowercase error string and simplify file writes

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_685ab6ff2814832e90ba3a3e86670260