### PR TITLE
Pass `--depth` for clones / forks via gitargs

### DIFF
--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -36,6 +36,7 @@ var (
 var (
 	forceFork bool
 	repoFile  string
+	depth     int
 )
 
 func NewCloneCmd() *cobra.Command {
@@ -47,6 +48,7 @@ func NewCloneCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&forceFork, "fork", false, "Force forking, instead of turbolift choosing whether to fork/branch based on permissions")
 	cmd.Flags().StringVar(&repoFile, "repos", "repos.txt", "A file containing a list of repositories to clone.")
+	cmd.Flags().IntVar(&depth, "depth", 0, "The maximum depth to clone repositories for")
 
 	return cmd
 }
@@ -107,9 +109,9 @@ func run(c *cobra.Command, _ []string) {
 		}
 
 		if fork {
-			err = gh.ForkAndClone(cloneActivity.Writer(), orgDirPath, repo.FullRepoName)
+			err = gh.ForkAndClone(cloneActivity.Writer(), orgDirPath, repo.FullRepoName, depth)
 		} else {
-			err = gh.Clone(cloneActivity.Writer(), orgDirPath, repo.FullRepoName)
+			err = gh.Clone(cloneActivity.Writer(), orgDirPath, repo.FullRepoName, depth)
 		}
 
 		if err != nil {

--- a/internal/github/fake_github.go
+++ b/internal/github/fake_github.go
@@ -18,6 +18,7 @@ package github
 import (
 	"errors"
 	"io"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,15 +48,21 @@ func (f *FakeGitHub) CreatePullRequest(_ io.Writer, workingDir string, metadata 
 	return f.handler(CreatePullRequest, args)
 }
 
-func (f *FakeGitHub) ForkAndClone(_ io.Writer, workingDir string, fullRepoName string) error {
+func (f *FakeGitHub) ForkAndClone(_ io.Writer, workingDir string, fullRepoName string, depth int) error {
 	args := []string{"fork_and_clone", workingDir, fullRepoName}
+	if depth > 0 {
+		args = []string{"fork_and_clone", workingDir, fullRepoName, "--", "--depth=" + strconv.Itoa(depth)}
+	}
 	f.calls = append(f.calls, args)
 	_, err := f.handler(ForkAndClone, args)
 	return err
 }
 
-func (f *FakeGitHub) Clone(_ io.Writer, workingDir string, fullRepoName string) error {
+func (f *FakeGitHub) Clone(_ io.Writer, workingDir string, fullRepoName string, depth int) error {
 	args := []string{"clone", workingDir, fullRepoName}
+	if depth > 0 {
+		args = []string{"clone", workingDir, fullRepoName, "--", "--depth=" + strconv.Itoa(depth)}
+	}
 	f.calls = append(f.calls, args)
 	_, err := f.handler(Clone, args)
 	return err

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/skyscanner/turbolift/internal/executor"
@@ -36,8 +37,8 @@ type PullRequest struct {
 }
 
 type GitHub interface {
-	ForkAndClone(output io.Writer, workingDir string, fullRepoName string) error
-	Clone(output io.Writer, workingDir string, fullRepoName string) error
+	ForkAndClone(output io.Writer, workingDir string, fullRepoName string, depth int) error
+	Clone(output io.Writer, workingDir string, fullRepoName string, depth int) error
 	CreatePullRequest(output io.Writer, workingDir string, metadata PullRequest) (didCreate bool, err error)
 	ClosePullRequest(output io.Writer, workingDir string, branchName string) error
 	UpdatePRDescription(output io.Writer, workingDir string, title string, body string) error
@@ -74,11 +75,17 @@ func (r *RealGitHub) CreatePullRequest(output io.Writer, workingDir string, pr P
 	return true, nil
 }
 
-func (r *RealGitHub) ForkAndClone(output io.Writer, workingDir string, fullRepoName string) error {
+func (r *RealGitHub) ForkAndClone(output io.Writer, workingDir string, fullRepoName string, depth int) error {
+	if depth > 0 {
+		return execInstance.Execute(output, workingDir, "gh", "repo", "fork", "--clone=true", fullRepoName, "--", "--depth="+strconv.Itoa(depth))
+	}
 	return execInstance.Execute(output, workingDir, "gh", "repo", "fork", "--clone=true", fullRepoName)
 }
 
-func (r *RealGitHub) Clone(output io.Writer, workingDir string, fullRepoName string) error {
+func (r *RealGitHub) Clone(output io.Writer, workingDir string, fullRepoName string, depth int) error {
+	if depth > 0 {
+		return execInstance.Execute(output, workingDir, "gh", "repo", "clone", fullRepoName, "--", "--depth="+strconv.Itoa(depth))
+	}
 	return execInstance.Execute(output, workingDir, "gh", "repo", "clone", fullRepoName)
 }
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -179,14 +179,14 @@ func TestItReturnsNilErrorOnSuccessfulUpdatePrDescription(t *testing.T) {
 
 func runForkAndCloneAndCaptureOutput() (string, error) {
 	sb := strings.Builder{}
-	err := NewRealGitHub().ForkAndClone(&sb, "work/org", "org/repo1")
+	err := NewRealGitHub().ForkAndClone(&sb, "work/org", "org/repo1", 0)
 
 	return sb.String(), err
 }
 
 func runCloneAndCaptureOutput() (string, error) {
 	sb := strings.Builder{}
-	err := NewRealGitHub().Clone(&sb, "work/org", "org/repo1")
+	err := NewRealGitHub().Clone(&sb, "work/org", "org/repo1", 0)
 
 	return sb.String(), err
 }


### PR DESCRIPTION
The `gh` cli `clone` and `fork` commands can take native git args:
```bash
gh repo clone --help

USAGE
  gh repo clone <repository> [<directory>] [-- <gitflags>...]
```

This PR enables passthrough of the native `--depth` argument so that bandwidth / storage space can be preserved on campaigns where history is not needed.

WIP: 
- docs need updated
- should this be a more generic change of 'allow passthrough of arbitrary git-native commands'?