### PR TITLE
Add clone --from-prs to assimilate existing PRs (fixes #215)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.txt
 .vscode
 .idea
 *.test
+/docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -122,10 +122,39 @@ By default the cloning policy is to create a branch to the target repository. If
 
 If you do want to fork all the repositories instead of letting turbolift deciding for you, use the `--fork` flag.
 
+If you want to assimilate existing PRs (e.g. PRs raised by a cloud agent or a teammate), use `--from-prs` — see [Assimilating existing PRs](#assimilating-existing-prs) below.
+
 Usage:
 ```console
 turbolift clone
 ```
+
+### Assimilating existing PRs
+
+Sometimes you need turbolift to pick up where someone else left off — for example, tidying up PRs raised by a cloud agent or a colleague. Use `--from-prs` to clone each repo and check out its PR branch in one step:
+
+```console
+turbolift init --name assimilation
+cd turbolift-assimilation
+# populate prs.txt with PR URLs or org/repo#N shorthand, one per line
+cat > prs.txt <<'EOF'
+https://github.com/org/repo1/pull/42
+org/repo2#7
+EOF
+turbolift clone --from-prs prs.txt
+# make your changes in work/**
+turbolift commit --message "Fix follow-up review feedback"
+turbolift update-prs --push
+```
+
+The PR head branch names are recorded as `# branch=<name>` annotations next to each repo in `repos.txt`, so subsequent `commit`, `update-prs`, and `pr-status` commands act on the correct branch per repo. For example, after assimilation your `repos.txt` might look like:
+
+```
+org/repo1 # branch=feature-x
+org/repo2 # branch=agent-fix-42
+```
+
+`--from-prs` and `--repos` are mutually exclusive. If `repos.txt` already contains a conflicting branch annotation for a repo, turbolift will stop and ask you to resolve manually — it will not overwrite your existing annotations.
 
 ### Making changes
 

--- a/README.md
+++ b/README.md
@@ -122,39 +122,10 @@ By default the cloning policy is to create a branch to the target repository. If
 
 If you do want to fork all the repositories instead of letting turbolift deciding for you, use the `--fork` flag.
 
-If you want to assimilate existing PRs (e.g. PRs raised by a cloud agent or a teammate), use `--from-prs` — see [Assimilating existing PRs](#assimilating-existing-prs) below.
-
 Usage:
 ```console
 turbolift clone
 ```
-
-### Assimilating existing PRs
-
-Sometimes you need turbolift to pick up where someone else left off — for example, tidying up PRs raised by a cloud agent or a colleague. Use `--from-prs` to clone each repo and check out its PR branch in one step:
-
-```console
-turbolift init --name assimilation
-cd turbolift-assimilation
-# populate prs.txt with PR URLs or org/repo#N shorthand, one per line
-cat > prs.txt <<'EOF'
-https://github.com/org/repo1/pull/42
-org/repo2#7
-EOF
-turbolift clone --from-prs prs.txt
-# make your changes in work/**
-turbolift commit --message "Fix follow-up review feedback"
-turbolift update-prs --push
-```
-
-The PR head branch names are recorded as `# branch=<name>` annotations next to each repo in `repos.txt`, so subsequent `commit`, `update-prs`, and `pr-status` commands act on the correct branch per repo. For example, after assimilation your `repos.txt` might look like:
-
-```
-org/repo1 # branch=feature-x
-org/repo2 # branch=agent-fix-42
-```
-
-`--from-prs` and `--repos` are mutually exclusive. If `repos.txt` already contains a conflicting branch annotation for a repo, turbolift will stop and ask you to resolve manually — it will not overwrite your existing annotations.
 
 ### Making changes
 
@@ -305,6 +276,33 @@ As always, use the `--repos` flag to specify an alternative repo file to the def
 Note that when updating PR descriptions, as when creating PRs, the `--description` flag can be used to specify an 
 alternative description file to the default `README.md`.
 The updated title is taken from the first line of the file, and the updated description is the remainder of the file contents.
+
+### Assimilating existing PRs
+
+Occasionally, rather than starting a campaign from scratch, you'll want turbolift to pick up PRs that already exist across a set of repos — for example, tidying up or pushing follow-ups to PRs raised by a cloud agent or a colleague. `turbolift clone --from-prs <file>` clones each repo and checks out its PR branch in one step:
+
+```console
+turbolift init --name assimilation
+cd turbolift-assimilation
+# populate prs.txt with PR URLs or org/repo#N shorthand, one per line
+cat > prs.txt <<'EOF'
+https://github.com/org/repo1/pull/42
+org/repo2#7
+EOF
+turbolift clone --from-prs prs.txt
+# make your changes in work/**
+turbolift commit --message "Fix follow-up review feedback"
+turbolift update-prs --push
+```
+
+The PR head branch names are recorded as `# branch=<name>` annotations next to each repo in `repos.txt`, so subsequent `commit`, `update-prs`, and `pr-status` commands act on the correct branch per repo. For example, after assimilation your `repos.txt` might look like:
+
+```
+org/repo1 # branch=feature-x
+org/repo2 # branch=agent-fix-42
+```
+
+`--from-prs` and `--repos` are mutually exclusive. If `repos.txt` already contains a conflicting branch annotation for a repo, turbolift will stop and ask you to resolve manually — it will not overwrite your existing annotations.
 
 ## Status: Preview
 

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -36,6 +36,7 @@ var (
 var (
 	forceFork bool
 	repoFile  string
+	prsFile   string
 )
 
 func NewCloneCmd() *cobra.Command {
@@ -47,11 +48,33 @@ func NewCloneCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&forceFork, "fork", false, "Force forking, instead of turbolift choosing whether to fork/branch based on permissions")
 	cmd.Flags().StringVar(&repoFile, "repos", "repos.txt", "A file containing a list of repositories to clone.")
+	cmd.Flags().StringVar(&prsFile, "from-prs", "",
+		"A file containing PR URLs or org/repo#N shorthand to assimilate. "+
+			"Each PR's head branch is checked out locally and recorded as a "+
+			"`# branch=<name>` annotation in repos.txt. Mutually exclusive with --repos.")
 
 	return cmd
 }
 
-func run(c *cobra.Command, _ []string) {
+func run(c *cobra.Command, args []string) {
+	logger := logging.NewLogger(c)
+
+	if prsFile != "" {
+		// Mutual exclusion: honouring both --from-prs and a user-specified
+		// --repos file would have ambiguous semantics (which list wins?), so
+		// reject early. --repos stays on its default value for the PR flow
+		// because we write into the default repos.txt.
+		if c.Flags().Changed("repos") {
+			logger.Errorf("--from-prs and --repos are mutually exclusive")
+			return
+		}
+		runFromPRs(c, args)
+		return
+	}
+	runNormal(c, args)
+}
+
+func runNormal(c *cobra.Command, _ []string) {
 	logger := logging.NewLogger(c)
 
 	readCampaignActivity := logger.StartActivity("Reading campaign data (%s)", repoFile)
@@ -163,4 +186,132 @@ func run(c *cobra.Command, _ []string) {
 	logger.Println("\t2. Add new files across all repos using", colors.Cyan(`turbolift foreach -- git add -A`))
 	logger.Println("\t3. Commit changes across all repos using", colors.Cyan(`turbolift commit --message "Your commit message"`))
 	logger.Println("\t4. Change the PR title and description in the", colors.Cyan(`README.md`), "of a campaign")
+}
+
+// runFromPRs implements `clone --from-prs`. It reads PR refs from prsFile,
+// clones each repo, runs `gh pr checkout` to land the PR's head branch, and
+// then records those branches as annotations in repos.txt. We do all clones
+// first and the repos.txt write last — this means a conflict detected by
+// UpsertBranchAnnotations leaves repos.txt untouched rather than half-written.
+func runFromPRs(c *cobra.Command, _ []string) {
+	logger := logging.NewLogger(c)
+
+	readActivity := logger.StartActivity("Reading PRs file (%s)", prsFile)
+	prs, err := campaign.ReadPRsFile(prsFile)
+	if err != nil {
+		readActivity.EndWithFailure(err)
+		return
+	}
+	readActivity.EndWithSuccess()
+
+	var doneCount, skippedCount, errorCount int
+	collectedBranches := map[string]string{}
+
+	for _, pr := range prs {
+		orgDirPath := path.Join("work", pr.OrgName)
+		repoDirPath := path.Join(orgDirPath, pr.RepoName)
+
+		// The identifier we pass to `gh` for clone/fork/push permission checks.
+		// For GHE PRs we include the host so `gh` hits the right instance.
+		cloneTarget := pr.OrgName + "/" + pr.RepoName
+		if pr.Host != "" {
+			cloneTarget = pr.Host + "/" + cloneTarget
+		}
+
+		activity := logger.StartActivity("Assimilating PR #%d for %s", pr.Number, cloneTarget)
+
+		if err := os.MkdirAll(orgDirPath, os.ModeDir|0o755); err != nil {
+			activity.EndWithFailuref("Unable to create org directory: %s", err)
+			errorCount++
+			continue
+		}
+
+		// Skip-if-present mirrors the normal clone flow. This makes retries
+		// safe: a user who hits a conflict, fixes repos.txt, and re-runs
+		// should not see clones redone or errors for already-done work.
+		if _, err := os.Stat(repoDirPath); !os.IsNotExist(err) {
+			activity.EndWithWarningf("Directory already exists")
+			skippedCount++
+			// Still capture the current branch so UpsertBranchAnnotations
+			// can reconcile. A missing branch here won't block success of
+			// other repos — the upsert treats it as "no update needed".
+			if b, bErr := g.GetCurrentBranchName(activity.Writer(), repoDirPath); bErr == nil {
+				collectedBranches[pr.FullRepoName()] = b
+			}
+			continue
+		}
+
+		// Decide fork vs direct clone using the same permission check as
+		// the normal flow. In practice assimilation usually implies direct
+		// clone (the PR author has push access) but honouring --fork keeps
+		// behaviour consistent.
+		var fork bool
+		if forceFork {
+			fork = true
+		} else {
+			res, permErr := gh.IsPushable(logger.Writer(), cloneTarget)
+			if permErr != nil {
+				logger.Warnf("Unable to determine if we can push to %s: %s", cloneTarget, permErr)
+				fork = true
+			} else {
+				fork = !res
+			}
+		}
+
+		if fork {
+			err = gh.ForkAndClone(activity.Writer(), orgDirPath, cloneTarget)
+		} else {
+			err = gh.Clone(activity.Writer(), orgDirPath, cloneTarget)
+		}
+		if err != nil {
+			activity.EndWithFailure(err)
+			errorCount++
+			continue
+		}
+
+		// `gh pr checkout` fetches the PR head and checks it out. For PRs
+		// from forks it also configures a remote and sets upstream tracking
+		// — that's why we use it instead of a hand-rolled git fetch+checkout.
+		if err := gh.CheckoutPR(activity.Writer(), repoDirPath, pr.Number); err != nil {
+			activity.EndWithFailure(err)
+			errorCount++
+			continue
+		}
+
+		// Capture the checked-out branch so we can record it in repos.txt.
+		branch, bErr := g.GetCurrentBranchName(activity.Writer(), repoDirPath)
+		if bErr != nil {
+			activity.EndWithFailure(bErr)
+			errorCount++
+			continue
+		}
+		collectedBranches[pr.FullRepoName()] = branch
+
+		activity.EndWithSuccess()
+		doneCount++
+	}
+
+	// Single atomic write. If any repo has a conflicting annotation already,
+	// this errors without touching the file and we surface the failure so the
+	// user can resolve manually before re-running.
+	upsertActivity := logger.StartActivity("Updating repos.txt with PR branch annotations")
+	if err := campaign.UpsertBranchAnnotations("repos.txt", collectedBranches); err != nil {
+		upsertActivity.EndWithFailure(err)
+		logger.Warnf("repos.txt was not modified. Resolve the conflict above and re-run.")
+	} else {
+		upsertActivity.EndWithSuccess()
+	}
+
+	if errorCount == 0 {
+		logger.Successf("turbolift clone completed %s(%s repos cloned, %s repos skipped)\n",
+			colors.Normal(), colors.Green(doneCount), colors.Yellow(skippedCount))
+	} else {
+		logger.Warnf("turbolift clone completed with %s %s(%s repos cloned, %s repos skipped, %s repos errored)\n",
+			colors.Red("errors"), colors.Normal(),
+			colors.Green(doneCount), colors.Yellow(skippedCount), colors.Red(errorCount))
+	}
+	logger.Println("To continue:")
+	logger.Println("\t1. Make your changes in the cloned repositories within the", colors.Cyan("work"), "directory")
+	logger.Println("\t2. Commit changes across all repos using", colors.Cyan(`turbolift commit --message "Your commit message"`))
+	logger.Println("\t3. Push the updated PR branches using", colors.Cyan(`turbolift update-prs --push`))
 }

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -51,7 +51,7 @@ func NewCloneCmd() *cobra.Command {
 	cmd.Flags().StringVar(&prsFile, "from-prs", "",
 		"A file containing PR URLs or org/repo#N shorthand to assimilate. "+
 			"Each PR's head branch is checked out locally and recorded as a "+
-			"`# branch=<name>` annotation in repos.txt. Mutually exclusive with --repos.")
+			"branch annotation in repos.txt. Mutually exclusive with --repos.")
 
 	return cmd
 }

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -235,8 +235,9 @@ func runFromPRs(c *cobra.Command, _ []string) {
 			// Still capture the current branch so UpsertBranchAnnotations
 			// can reconcile. Key by cloneTarget (not FullRepoName) so GHE
 			// repos.txt entries like `host/org/repo` match — FullRepoName
-			// deliberately strips the host.
-			if b, bErr := g.GetCurrentBranchName(activity.Writer(), repoDirPath); bErr == nil {
+			// deliberately strips the host. Skip if we're in detached HEAD
+			// ("HEAD") to avoid writing a literal "HEAD" into repos.txt.
+			if b, bErr := g.GetCurrentBranchName(activity.Writer(), repoDirPath); bErr == nil && b != "HEAD" {
 				collectedBranches[cloneTarget] = b
 			}
 			continue
@@ -286,6 +287,14 @@ func runFromPRs(c *cobra.Command, _ []string) {
 		branch, bErr := g.GetCurrentBranchName(activity.Writer(), repoDirPath)
 		if bErr != nil {
 			activity.EndWithFailure(bErr)
+			errorCount++
+			continue
+		}
+		// A literal "HEAD" means detached state — refuse to record that as a
+		// branch name, since downstream commands would then try to push to a
+		// branch called "HEAD" with confusing results.
+		if branch == "HEAD" {
+			activity.EndWithFailuref("detached HEAD after checkout of PR #%d — not recording branch", pr.Number)
 			errorCount++
 			continue
 		}

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -226,54 +226,51 @@ func runFromPRs(c *cobra.Command, _ []string) {
 			continue
 		}
 
-		// Skip-if-present mirrors the normal clone flow. This makes retries
-		// safe: a user who hits a conflict, fixes repos.txt, and re-runs
-		// should not see clones redone or errors for already-done work.
+		// If the directory is already present we skip the clone step but
+		// still run `gh pr checkout` — this guards against the case where a
+		// previous run crashed between clone and checkout, leaving the repo
+		// on the default branch. `gh pr checkout` is idempotent: if we're
+		// already on the PR branch it's a no-op.
+		alreadyCloned := false
 		if _, err := os.Stat(repoDirPath); !os.IsNotExist(err) {
-			activity.EndWithWarningf("Directory already exists")
-			skippedCount++
-			// Still capture the current branch so UpsertBranchAnnotations
-			// can reconcile. Key by cloneTarget (not FullRepoName) so GHE
-			// repos.txt entries like `host/org/repo` match — FullRepoName
-			// deliberately strips the host. Skip if we're in detached HEAD
-			// ("HEAD") to avoid writing a literal "HEAD" into repos.txt.
-			if b, bErr := g.GetCurrentBranchName(activity.Writer(), repoDirPath); bErr == nil && b != "HEAD" {
-				collectedBranches[cloneTarget] = b
-			}
-			continue
+			alreadyCloned = true
 		}
 
-		// Decide fork vs direct clone using the same permission check as
-		// the normal flow. In practice assimilation usually implies direct
-		// clone (the PR author has push access) but honouring --fork keeps
-		// behaviour consistent.
-		var fork bool
-		if forceFork {
-			fork = true
-		} else {
-			res, permErr := gh.IsPushable(logger.Writer(), cloneTarget)
-			if permErr != nil {
-				logger.Warnf("Unable to determine if we can push to %s: %s", cloneTarget, permErr)
+		if !alreadyCloned {
+			// Decide fork vs direct clone using the same permission check as
+			// the normal flow. In practice assimilation usually implies direct
+			// clone (the PR author has push access) but honouring --fork keeps
+			// behaviour consistent.
+			var fork bool
+			if forceFork {
 				fork = true
 			} else {
-				fork = !res
+				res, permErr := gh.IsPushable(logger.Writer(), cloneTarget)
+				if permErr != nil {
+					logger.Warnf("Unable to determine if we can push to %s: %s", cloneTarget, permErr)
+					fork = true
+				} else {
+					fork = !res
+				}
 			}
-		}
 
-		if fork {
-			err = gh.ForkAndClone(activity.Writer(), orgDirPath, cloneTarget)
-		} else {
-			err = gh.Clone(activity.Writer(), orgDirPath, cloneTarget)
-		}
-		if err != nil {
-			activity.EndWithFailure(err)
-			errorCount++
-			continue
+			if fork {
+				err = gh.ForkAndClone(activity.Writer(), orgDirPath, cloneTarget)
+			} else {
+				err = gh.Clone(activity.Writer(), orgDirPath, cloneTarget)
+			}
+			if err != nil {
+				activity.EndWithFailure(err)
+				errorCount++
+				continue
+			}
 		}
 
 		// `gh pr checkout` fetches the PR head and checks it out. For PRs
 		// from forks it also configures a remote and sets upstream tracking
 		// — that's why we use it instead of a hand-rolled git fetch+checkout.
+		// Always run this, even when skipping the clone step, so incomplete
+		// prior runs can recover.
 		if err := gh.CheckoutPR(activity.Writer(), repoDirPath, pr.Number); err != nil {
 			activity.EndWithFailure(err)
 			errorCount++
@@ -300,8 +297,13 @@ func runFromPRs(c *cobra.Command, _ []string) {
 		}
 		collectedBranches[cloneTarget] = branch
 
-		activity.EndWithSuccess()
-		doneCount++
+		if alreadyCloned {
+			activity.EndWithWarningf("Directory already existed; re-ran PR checkout")
+			skippedCount++
+		} else {
+			activity.EndWithSuccess()
+			doneCount++
+		}
 	}
 
 	// Single atomic write. If any repo has a conflicting annotation already,

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -308,11 +308,15 @@ func runFromPRs(c *cobra.Command, _ []string) {
 
 	// Single atomic write. If any repo has a conflicting annotation already,
 	// this errors without touching the file and we surface the failure so the
-	// user can resolve manually before re-running.
+	// user can resolve manually before re-running. Count it as an error so
+	// the final summary doesn't misleadingly claim success while repos.txt is
+	// stale — the PR branches aren't recorded and downstream commands would
+	// fall back to the campaign name, which is likely wrong.
 	upsertActivity := logger.StartActivity("Updating repos.txt with PR branch annotations")
 	if err := campaign.UpsertBranchAnnotations("repos.txt", collectedBranches); err != nil {
 		upsertActivity.EndWithFailure(err)
 		logger.Warnf("repos.txt was not modified. Resolve the conflict above and re-run.")
+		errorCount++
 	} else {
 		upsertActivity.EndWithSuccess()
 	}

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -233,10 +233,11 @@ func runFromPRs(c *cobra.Command, _ []string) {
 			activity.EndWithWarningf("Directory already exists")
 			skippedCount++
 			// Still capture the current branch so UpsertBranchAnnotations
-			// can reconcile. A missing branch here won't block success of
-			// other repos — the upsert treats it as "no update needed".
+			// can reconcile. Key by cloneTarget (not FullRepoName) so GHE
+			// repos.txt entries like `host/org/repo` match — FullRepoName
+			// deliberately strips the host.
 			if b, bErr := g.GetCurrentBranchName(activity.Writer(), repoDirPath); bErr == nil {
-				collectedBranches[pr.FullRepoName()] = b
+				collectedBranches[cloneTarget] = b
 			}
 			continue
 		}
@@ -279,13 +280,16 @@ func runFromPRs(c *cobra.Command, _ []string) {
 		}
 
 		// Capture the checked-out branch so we can record it in repos.txt.
+		// Key by cloneTarget (not FullRepoName) so GHE repos.txt entries like
+		// `host/org/repo` match the right line when UpsertBranchAnnotations
+		// looks them up.
 		branch, bErr := g.GetCurrentBranchName(activity.Writer(), repoDirPath)
 		if bErr != nil {
 			activity.EndWithFailure(bErr)
 			errorCount++
 			continue
 		}
-		collectedBranches[pr.FullRepoName()] = branch
+		collectedBranches[cloneTarget] = branch
 
 		activity.EndWithSuccess()
 		doneCount++

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -56,7 +56,7 @@ func NewCloneCmd() *cobra.Command {
 	return cmd
 }
 
-func run(c *cobra.Command, args []string) {
+func run(c *cobra.Command, _ []string) {
 	logger := logging.NewLogger(c)
 
 	if prsFile != "" {
@@ -68,13 +68,13 @@ func run(c *cobra.Command, args []string) {
 			logger.Errorf("--from-prs and --repos are mutually exclusive")
 			return
 		}
-		runFromPRs(c, args)
+		runFromPRs(c)
 		return
 	}
-	runNormal(c, args)
+	runNormal(c)
 }
 
-func runNormal(c *cobra.Command, _ []string) {
+func runNormal(c *cobra.Command) {
 	logger := logging.NewLogger(c)
 
 	readCampaignActivity := logger.StartActivity("Reading campaign data (%s)", repoFile)
@@ -193,7 +193,7 @@ func runNormal(c *cobra.Command, _ []string) {
 // then records those branches as annotations in repos.txt. We do all clones
 // first and the repos.txt write last — this means a conflict detected by
 // UpsertBranchAnnotations leaves repos.txt untouched rather than half-written.
-func runFromPRs(c *cobra.Command, _ []string) {
+func runFromPRs(c *cobra.Command) {
 	logger := logging.NewLogger(c)
 
 	readActivity := logger.StartActivity("Reading PRs file (%s)", prsFile)

--- a/cmd/clone/clone_test.go
+++ b/cmd/clone/clone_test.go
@@ -623,6 +623,10 @@ func TestCloneFromPRsFailsOnConflictingExistingAnnotation(t *testing.T) {
 	out, err := runCloneCommandArgs([]string{"--from-prs", "prs.txt"})
 	assert.NoError(t, err)
 	assert.Contains(t, out, "conflicting")
+	// Summary must reflect the upsert failure — otherwise a user who only
+	// reads the final line thinks repos.txt was updated when it wasn't.
+	assert.Contains(t, out, "completed with")
+	assert.Contains(t, out, "errors")
 
 	// UpsertBranchAnnotations is atomic — file must be byte-identical.
 	afterRepos, _ := os.ReadFile("repos.txt")

--- a/cmd/clone/clone_test.go
+++ b/cmd/clone/clone_test.go
@@ -524,6 +524,48 @@ func TestCloneFromPRsKeysBranchesByHostOrgRepoForGHE(t *testing.T) {
 	assert.Contains(t, string(reposContent), "my-ghe.example/org/repo1 # branch=feat/fix")
 }
 
+func TestCloneFromPRsRerunsCheckoutWhenDirectoryExists(t *testing.T) {
+	// Guards against the "crashed between clone and checkout" case: if the
+	// work/ dir is there but we never successfully checked out the PR, we'd
+	// record the wrong branch (e.g. main) into repos.txt. The fix is to
+	// always run `gh pr checkout` — it's idempotent.
+	fakeGitHub := github.NewFakeGitHub(func(command github.Command, args []string) (bool, error) {
+		switch command {
+		case github.IsPushable, github.Clone, github.CheckoutPR:
+			return true, nil
+		default:
+			return false, errors.New("unexpected command")
+		}
+	}, func(workingDir string) (interface{}, error) { return nil, nil })
+	gh = fakeGitHub
+
+	fakeGit := git.NewAlwaysSucceedsFakeGit()
+	fakeGit.SetCurrentBranchName("work/org/repo1", "feat/fix")
+	g = fakeGit
+
+	testsupport.PrepareTempCampaign(false)
+	// Simulate an existing clone from a prior run.
+	assert.NoError(t, os.MkdirAll(path.Join("work", "org", "repo1"), os.ModeDir|0o755))
+	assert.NoError(t, os.WriteFile("prs.txt", []byte("org/repo1#1\n"), 0o644))
+
+	out, err := runCloneCommandArgs([]string{"--from-prs", "prs.txt"})
+	assert.NoError(t, err)
+	// Should have run checkout_pr even for the already-cloned repo.
+	assertContainsCall(t, fakeGitHub.Calls(), []string{"checkout_pr", "work/org/repo1", "1"})
+	// Should NOT have re-cloned.
+	for _, c := range fakeGitHub.Calls() {
+		if len(c) >= 1 && c[0] == "clone" {
+			t.Errorf("expected no clone call for already-present dir, got %v", c)
+		}
+	}
+	assert.Contains(t, out, "Directory already existed; re-ran PR checkout")
+
+	// Branch annotation should still be recorded.
+	reposContent, err := os.ReadFile("repos.txt")
+	assert.NoError(t, err)
+	assert.Contains(t, string(reposContent), "org/repo1 # branch=feat/fix")
+}
+
 func TestCloneFromPRsFailsOnDetachedHEAD(t *testing.T) {
 	// If `gh pr checkout` lands us on a detached HEAD somehow, GetCurrentBranchName
 	// returns the literal "HEAD". We must NOT write that into repos.txt — downstream

--- a/cmd/clone/clone_test.go
+++ b/cmd/clone/clone_test.go
@@ -524,6 +524,38 @@ func TestCloneFromPRsKeysBranchesByHostOrgRepoForGHE(t *testing.T) {
 	assert.Contains(t, string(reposContent), "my-ghe.example/org/repo1 # branch=feat/fix")
 }
 
+func TestCloneFromPRsFailsOnDetachedHEAD(t *testing.T) {
+	// If `gh pr checkout` lands us on a detached HEAD somehow, GetCurrentBranchName
+	// returns the literal "HEAD". We must NOT write that into repos.txt — downstream
+	// push/close/lookup would then act on a branch called "HEAD" with confusing
+	// results. Treat detached HEAD as a per-repo error and continue.
+	fakeGitHub := github.NewFakeGitHub(func(command github.Command, args []string) (bool, error) {
+		switch command {
+		case github.IsPushable, github.Clone, github.CheckoutPR:
+			return true, nil
+		default:
+			return false, errors.New("unexpected command")
+		}
+	}, func(workingDir string) (interface{}, error) { return nil, nil })
+	gh = fakeGitHub
+
+	fakeGit := git.NewAlwaysSucceedsFakeGit()
+	fakeGit.SetCurrentBranchName("work/org/repo1", "HEAD") // simulate detached HEAD
+	g = fakeGit
+
+	testsupport.PrepareTempCampaign(false)
+	assert.NoError(t, os.WriteFile("prs.txt", []byte("org/repo1#1\n"), 0o644))
+
+	out, err := runCloneCommandArgs([]string{"--from-prs", "prs.txt"})
+	assert.NoError(t, err)
+	assert.Contains(t, out, "detached HEAD")
+
+	// repos.txt must NOT contain a `branch=HEAD` line.
+	reposContent, err := os.ReadFile("repos.txt")
+	assert.NoError(t, err)
+	assert.NotContains(t, string(reposContent), "branch=HEAD")
+}
+
 func TestCloneFromPRsFailsOnConflictingExistingAnnotation(t *testing.T) {
 	fakeGitHub := github.NewFakeGitHub(func(command github.Command, args []string) (bool, error) {
 		switch command {

--- a/cmd/clone/clone_test.go
+++ b/cmd/clone/clone_test.go
@@ -493,6 +493,37 @@ func TestCloneFromPRsHappyPath(t *testing.T) {
 	assertContainsCall(t, calls, []string{"checkout_pr", "work/org/repo2", "2"})
 }
 
+func TestCloneFromPRsKeysBranchesByHostOrgRepoForGHE(t *testing.T) {
+	// For a GHE PR URL, repos.txt stores `host/org/repo` and the branch
+	// annotation must be keyed on that same full identifier — otherwise the
+	// upsert won't find the existing line and we'd either append a duplicate
+	// or lose the host prefix.
+	fakeGitHub := github.NewFakeGitHub(func(command github.Command, args []string) (bool, error) {
+		switch command {
+		case github.IsPushable, github.Clone, github.CheckoutPR:
+			return true, nil
+		default:
+			return false, errors.New("unexpected command")
+		}
+	}, func(workingDir string) (interface{}, error) { return nil, nil })
+	gh = fakeGitHub
+
+	fakeGit := git.NewAlwaysSucceedsFakeGit()
+	fakeGit.SetCurrentBranchName("work/org/repo1", "feat/fix")
+	g = fakeGit
+
+	testsupport.PrepareTempCampaign(false) // empty repos.txt
+	assert.NoError(t, os.WriteFile("prs.txt", []byte("https://my-ghe.example/org/repo1/pull/1\n"), 0o644))
+
+	_, err := runCloneCommandArgs([]string{"--from-prs", "prs.txt"})
+	assert.NoError(t, err)
+
+	// repos.txt must carry the host-qualified repo name, not `org/repo1`.
+	reposContent, err := os.ReadFile("repos.txt")
+	assert.NoError(t, err)
+	assert.Contains(t, string(reposContent), "my-ghe.example/org/repo1 # branch=feat/fix")
+}
+
 func TestCloneFromPRsFailsOnConflictingExistingAnnotation(t *testing.T) {
 	fakeGitHub := github.NewFakeGitHub(func(command github.Command, args []string) (bool, error) {
 		switch command {

--- a/cmd/clone/clone_test.go
+++ b/cmd/clone/clone_test.go
@@ -18,6 +18,7 @@ package clone
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -437,16 +438,114 @@ func TestItForksIfPermissionsCheckFails(t *testing.T) {
 	})
 }
 
-func runCloneCommand() (string, error) {
-	cmd := NewCloneCmd()
-	outBuffer := bytes.NewBufferString("")
-	cmd.SetOut(outBuffer)
-	forceFork = false
-	err := cmd.Execute()
-	if err != nil {
-		return outBuffer.String(), err
+func TestFromPRsAndReposAreMutuallyExclusive(t *testing.T) {
+	fakeGitHub := github.NewAlwaysSucceedsFakeGitHub()
+	gh = fakeGitHub
+	fakeGit := git.NewAlwaysSucceedsFakeGit()
+	g = fakeGit
+
+	testsupport.PrepareTempCampaign(false)
+	assert.NoError(t, os.WriteFile("prs.txt", []byte("org/repo#1\n"), 0o644))
+	assert.NoError(t, os.WriteFile("my-custom-repos.txt", []byte(""), 0o644))
+
+	// Pass flags via SetArgs so cobra's Changed() detection works — setting
+	// the package-level vars directly doesn't mark the flag as user-provided.
+	out, err := runCloneCommandArgs([]string{"--from-prs", "prs.txt", "--repos", "my-custom-repos.txt"})
+	assert.NoError(t, err)
+	assert.Contains(t, out, "mutually exclusive")
+}
+
+func TestCloneFromPRsHappyPath(t *testing.T) {
+	fakeGitHub := github.NewFakeGitHub(func(command github.Command, args []string) (bool, error) {
+		switch command {
+		case github.IsPushable, github.Clone, github.CheckoutPR:
+			return true, nil
+		default:
+			return false, errors.New("unexpected command " + fmt.Sprint(command))
+		}
+	}, func(workingDir string) (interface{}, error) {
+		return nil, errors.New("unexpected")
+	})
+	gh = fakeGitHub
+
+	fakeGit := git.NewAlwaysSucceedsFakeGit()
+	// After CheckoutPR, the fake returns the PR's head branch per repo.
+	fakeGit.SetCurrentBranchName("work/org/repo1", "feat/fix-1")
+	fakeGit.SetCurrentBranchName("work/org/repo2", "feat/fix-2")
+	g = fakeGit
+
+	testsupport.PrepareTempCampaign(false) // empty repos.txt (just a few template comments)
+	assert.NoError(t, os.WriteFile("prs.txt", []byte("org/repo1#1\norg/repo2#2\n"), 0o644))
+
+	out, err := runCloneCommandArgs([]string{"--from-prs", "prs.txt"})
+	assert.NoError(t, err)
+	assert.Contains(t, out, "Assimilating PR #1 for org/repo1")
+	assert.Contains(t, out, "Assimilating PR #2 for org/repo2")
+	assert.Contains(t, out, "turbolift clone completed (2 repos cloned, 0 repos skipped)")
+
+	reposContent, err := os.ReadFile("repos.txt")
+	assert.NoError(t, err)
+	assert.Contains(t, string(reposContent), "org/repo1 # branch=feat/fix-1")
+	assert.Contains(t, string(reposContent), "org/repo2 # branch=feat/fix-2")
+
+	calls := fakeGitHub.Calls()
+	assertContainsCall(t, calls, []string{"checkout_pr", "work/org/repo1", "1"})
+	assertContainsCall(t, calls, []string{"checkout_pr", "work/org/repo2", "2"})
+}
+
+func TestCloneFromPRsFailsOnConflictingExistingAnnotation(t *testing.T) {
+	fakeGitHub := github.NewFakeGitHub(func(command github.Command, args []string) (bool, error) {
+		switch command {
+		case github.IsPushable, github.Clone, github.CheckoutPR:
+			return true, nil
+		default:
+			return false, errors.New("unexpected")
+		}
+	}, func(workingDir string) (interface{}, error) { return nil, nil })
+	gh = fakeGitHub
+
+	fakeGit := git.NewAlwaysSucceedsFakeGit()
+	// PR checkout lands us on a different branch than what's already
+	// annotated in repos.txt — that's the conflict we want to detect.
+	fakeGit.SetCurrentBranchName("work/org/repo1", "new-branch")
+	g = fakeGit
+
+	testsupport.PrepareTempCampaign(false, "org/repo1 # branch=old-branch")
+	assert.NoError(t, os.WriteFile("prs.txt", []byte("org/repo1#1\n"), 0o644))
+
+	originalRepos, _ := os.ReadFile("repos.txt")
+
+	out, err := runCloneCommandArgs([]string{"--from-prs", "prs.txt"})
+	assert.NoError(t, err)
+	assert.Contains(t, out, "conflicting")
+
+	// UpsertBranchAnnotations is atomic — file must be byte-identical.
+	afterRepos, _ := os.ReadFile("repos.txt")
+	assert.Equal(t, string(originalRepos), string(afterRepos))
+}
+
+func assertContainsCall(t *testing.T, calls [][]string, want []string) {
+	t.Helper()
+	for _, c := range calls {
+		if len(c) != len(want) {
+			continue
+		}
+		match := true
+		for i := range c {
+			if c[i] != want[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return
+		}
 	}
-	return outBuffer.String(), nil
+	t.Errorf("expected call %v not found in %v", want, calls)
+}
+
+func runCloneCommand() (string, error) {
+	return runCloneCommandArgs(nil)
 }
 
 func runCloneCommandWithFork() (string, error) {
@@ -454,6 +553,23 @@ func runCloneCommandWithFork() (string, error) {
 	outBuffer := bytes.NewBufferString("")
 	cmd.SetOut(outBuffer)
 	forceFork = true
+	prsFile = ""
+	repoFile = "repos.txt"
+	err := cmd.Execute()
+	if err != nil {
+		return outBuffer.String(), err
+	}
+	return outBuffer.String(), nil
+}
+
+func runCloneCommandArgs(args []string) (string, error) {
+	cmd := NewCloneCmd()
+	outBuffer := bytes.NewBufferString("")
+	cmd.SetOut(outBuffer)
+	forceFork = false
+	prsFile = ""
+	repoFile = "repos.txt"
+	cmd.SetArgs(args)
 	err := cmd.Execute()
 	if err != nil {
 		return outBuffer.String(), err

--- a/cmd/create_prs/create_prs.go
+++ b/cmd/create_prs/create_prs.go
@@ -101,7 +101,10 @@ func run(c *cobra.Command, _ []string) {
 			continue
 		}
 
-		err := g.Push(pushActivity.Writer(), repoDirPath, "origin", dir.Name)
+		// Use repo.Branch: in normal flow this is the campaign name (populated
+		// by OpenCampaign) but for PR-assimilation campaigns it's the PR's
+		// head ref, so we push the right branch for assimilated PRs.
+		err := g.Push(pushActivity.Writer(), repoDirPath, "origin", repo.Branch)
 		if err != nil {
 			pushActivity.EndWithFailure(err)
 			errorCount++

--- a/cmd/create_prs/create_prs_test.go
+++ b/cmd/create_prs/create_prs_test.go
@@ -17,6 +17,7 @@ package create_prs
 
 import (
 	"bytes"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -217,6 +218,33 @@ func TestItCreatesPrsFromAlternativeDescriptionFile(t *testing.T) {
 	fakeGitHub.AssertCalledWith(t, [][]string{
 		{"create_pull_request", "work/org/repo1", "custom PR title"},
 		{"create_pull_request", "work/org/repo2", "custom PR title"},
+	})
+}
+
+func TestItPushesPerRepoBranchWhenAnnotated(t *testing.T) {
+	fakeGitHub := github.NewAlwaysSucceedsFakeGitHub()
+	gh = fakeGitHub
+	fakeGit := git.NewAlwaysSucceedsFakeGit()
+	g = fakeGit
+
+	// repo1 has an annotated branch; repo2 falls back to the campaign name.
+	// We rewrite repos.txt after PrepareTempCampaign so the annotation
+	// doesn't get mangled into directory names during setup.
+	testsupport.PrepareTempCampaign(true, "org/repo1", "org/repo2")
+	reposContent := "org/repo1 # branch=pr-branch\norg/repo2\n"
+	if err := os.WriteFile("repos.txt", []byte(reposContent), 0o644); err != nil {
+		t.Fatalf("write repos.txt: %v", err)
+	}
+
+	_, err := runCommand()
+	assert.NoError(t, err)
+
+	// Confirm push was called per-repo with the correct branch. The campaign
+	// name is the basename of the temp directory (starts with "turbolift-").
+	campaignBranch := testsupport.Pwd()
+	fakeGit.AssertCalledWith(t, [][]string{
+		{"push", "work/org/repo1", "pr-branch"},
+		{"push", "work/org/repo2", campaignBranch},
 	})
 }
 

--- a/cmd/prstatus/prstatus.go
+++ b/cmd/prstatus/prstatus.go
@@ -105,7 +105,9 @@ func run(c *cobra.Command, _ []string) {
 			continue
 		}
 
-		prStatus, err := gh.GetPR(checkStatusActivity.Writer(), repoDirPath, dir.Name)
+		// Use repo.Branch so we can look up PRs on assimilated branches; in
+		// the normal flow this equals dir.Name (default populated in OpenCampaign).
+		prStatus, err := gh.GetPR(checkStatusActivity.Writer(), repoDirPath, repo.Branch)
 		if err != nil {
 			checkStatusActivity.EndWithFailuref("No PR found: %v", err)
 			statuses["NO_PR"]++

--- a/cmd/prstatus/prstatus_test.go
+++ b/cmd/prstatus/prstatus_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -104,6 +105,38 @@ func TestItNotesReposWhereNoPrCanBeFound(t *testing.T) {
 	assert.Regexp(t, "No PR Found\\s+1", out)
 
 	assert.Regexp(t, "org/repo1\\s+OPEN", out)
+}
+
+func TestItLooksUpPerRepoBranchWhenAnnotated(t *testing.T) {
+	// Customised fake that records which branch is asked for, then returns
+	// a generic PR status. We assert that the branch passed in is the one
+	// annotated in repos.txt, not the campaign name.
+	var seenBranches []string
+	fakeGitHub := github.NewFakeGitHub(nil, func(workingDir string) (interface{}, error) {
+		return &github.PrStatus{State: "OPEN"}, nil
+	})
+	gh = fakeGitHub
+
+	tempDir := testsupport.PrepareTempCampaign(true, "org/repo1", "org/repo2")
+	if err := os.WriteFile("repos.txt", []byte("org/repo1 # branch=pr-branch\norg/repo2\n"), 0o644); err != nil {
+		t.Fatalf("write repos.txt: %v", err)
+	}
+
+	_, err := runCommand(true)
+	assert.NoError(t, err)
+
+	// Harvest the branches from the recorded calls — each "get_pr" entry is
+	// {"get_pr", workingDir, branchName}.
+	for _, call := range fakeGitHub.Calls() {
+		if len(call) == 3 && call[0] == "get_pr" {
+			seenBranches = append(seenBranches, call[2])
+		}
+	}
+	// PrepareTempCampaign gives tempDir names already prefixed with
+	// "turbolift-", so ApplyCampaignNamePrefix is a no-op and the campaign
+	// name equals the basename.
+	campaignName := filepath.Base(tempDir)
+	assert.Equal(t, []string{"pr-branch", campaignName}, seenBranches)
 }
 
 func runCommand(showList bool) (string, error) {

--- a/cmd/updateprs/updateprs.go
+++ b/cmd/updateprs/updateprs.go
@@ -134,7 +134,9 @@ func runClose(c *cobra.Command, _ []string) {
 			continue
 		}
 
-		err = gh.ClosePullRequest(closeActivity.Writer(), repo.FullRepoPath(), dir.Name)
+		// Use repo.Branch so PRs on assimilated branches close cleanly; in
+		// the normal flow this equals dir.Name (set by OpenCampaign's default).
+		err = gh.ClosePullRequest(closeActivity.Writer(), repo.FullRepoPath(), repo.Branch)
 		if err != nil {
 			if _, ok := err.(*github.NoPRFoundError); ok {
 				closeActivity.EndWithWarning(err)
@@ -246,7 +248,9 @@ func runPush(c *cobra.Command, _ []string) {
 			continue
 		}
 
-		err := g.Push(pushActivity.Writer(), repo.FullRepoPath(), "origin", dir.Name)
+		// Use repo.Branch so assimilated PRs push to the PR's head ref;
+		// in the normal flow this equals dir.Name.
+		err := g.Push(pushActivity.Writer(), repo.FullRepoPath(), "origin", repo.Branch)
 		if err != nil {
 			pushActivity.EndWithFailure(err)
 			errorCount++

--- a/cmd/updateprs/updateprs_test.go
+++ b/cmd/updateprs/updateprs_test.go
@@ -2,12 +2,13 @@ package updateprs
 
 import (
 	"bytes"
-	"github.com/skyscanner/turbolift/internal/git"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/skyscanner/turbolift/internal/git"
 	"github.com/skyscanner/turbolift/internal/github"
 	"github.com/skyscanner/turbolift/internal/prompt"
 	"github.com/skyscanner/turbolift/internal/testsupport"
@@ -222,6 +223,50 @@ func TestItLogsPushErrorsButContinuesToTryAll(t *testing.T) {
 	fakeGit.AssertCalledWith(t, [][]string{
 		{"push", "work/org/repo1", filepath.Base(tempDir)},
 		{"push", "work/org/repo2", filepath.Base(tempDir)},
+	})
+}
+
+func TestItPushesPerRepoBranchWhenAnnotated(t *testing.T) {
+	fakeGitHub := github.NewAlwaysSucceedsFakeGitHub()
+	gh = fakeGitHub
+	fakeGit := git.NewAlwaysSucceedsFakeGit()
+	g = fakeGit
+
+	tempDir := testsupport.PrepareTempCampaign(true, "org/repo1", "org/repo2")
+	// Rewrite repos.txt after setup so the annotation doesn't get mangled
+	// into directory names during PrepareTempCampaign's dir creation.
+	if err := os.WriteFile("repos.txt", []byte("org/repo1 # branch=pr-branch\norg/repo2\n"), 0o644); err != nil {
+		t.Fatalf("write repos.txt: %v", err)
+	}
+
+	_, err := runPushCommandAuto()
+	assert.NoError(t, err)
+
+	campaignBranch := filepath.Base(tempDir)
+	fakeGit.AssertCalledWith(t, [][]string{
+		{"push", "work/org/repo1", "pr-branch"},
+		{"push", "work/org/repo2", campaignBranch},
+	})
+}
+
+func TestItClosesPerRepoBranchWhenAnnotated(t *testing.T) {
+	fakeGitHub := github.NewAlwaysSucceedsFakeGitHub()
+	gh = fakeGitHub
+	fakeGit := git.NewAlwaysSucceedsFakeGit()
+	g = fakeGit
+
+	tempDir := testsupport.PrepareTempCampaign(true, "org/repo1", "org/repo2")
+	if err := os.WriteFile("repos.txt", []byte("org/repo1 # branch=pr-branch\norg/repo2\n"), 0o644); err != nil {
+		t.Fatalf("write repos.txt: %v", err)
+	}
+
+	_, err := runCloseCommandAuto()
+	assert.NoError(t, err)
+
+	campaignBranch := filepath.Base(tempDir)
+	fakeGitHub.AssertCalledWith(t, [][]string{
+		{"close_pull_request", "work/org/repo1", "pr-branch"},
+		{"close_pull_request", "work/org/repo2", campaignBranch},
 	})
 }
 

--- a/internal/campaign/campaign.go
+++ b/internal/campaign/campaign.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -31,7 +32,18 @@ type Repo struct {
 	OrgName      string
 	RepoName     string
 	FullRepoName string
+	// Branch is the git branch to operate on for this repo. Defaults to the
+	// campaign name during OpenCampaign when no `# branch=...` annotation is
+	// present in repos.txt. Populated explicitly when `clone --from-prs`
+	// assimilates existing PRs with non-matching head refs.
+	Branch string
 }
+
+// branchAnnotationRegexp matches a whitespace-bounded `branch=<value>` token
+// within a trailing comment in repos.txt. Any other text in the comment is
+// free-form and ignored by the tool, so users can combine branch annotations
+// with arbitrary notes.
+var branchAnnotationRegexp = regexp.MustCompile(`\bbranch=(\S+)`)
 
 type Campaign struct {
 	Name    string
@@ -66,6 +78,7 @@ func ApplyCampaignNamePrefix(name string) string {
 func OpenCampaign(options *CampaignOptions) (*Campaign, error) {
 	dir, _ := os.Getwd()
 	dirBasename := filepath.Base(dir)
+	name := ApplyCampaignNamePrefix(dirBasename)
 
 	repos, err := readReposTxtFile(options.RepoFilename)
 	if err != nil {
@@ -77,8 +90,18 @@ func OpenCampaign(options *CampaignOptions) (*Campaign, error) {
 		return nil, err
 	}
 
+	// Ensure every repo has a non-empty Branch. Downstream commands can then
+	// use repo.Branch unconditionally without having to fall back to the
+	// campaign name — and `--from-prs` callers that populate Branch from PR
+	// head refs take precedence over this default.
+	for i := range repos {
+		if repos[i].Branch == "" {
+			repos[i].Branch = name
+		}
+	}
+
 	return &Campaign{
-		Name:    ApplyCampaignNamePrefix(dirBasename),
+		Name:    name,
 		Repos:   repos,
 		PrTitle: prTitle,
 		PrBody:  prBody,
@@ -101,39 +124,68 @@ func readReposTxtFile(filename string) ([]Repo, error) {
 	}()
 
 	scanner := bufio.NewScanner(file)
-	uniq := map[string]interface{}{}
+	// branchByRepo tracks the branch annotation we've seen for each repo.
+	// We dedupe identical-in-every-way entries silently, but we error loudly
+	// when the same repo appears with conflicting branch annotations — that
+	// almost certainly indicates a bug in whoever wrote the file.
+	branchByRepo := map[string]string{}
 	var repos []Repo
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "#") && len(line) > 0 {
-			if _, seen := uniq[line]; seen {
-				continue
-			}
-			uniq[line] = struct{}{}
-
-			splitLine := strings.Split(line, "/")
-			numParts := len(splitLine)
-
-			var repo Repo
-			switch numParts {
-			case 2:
-				repo = Repo{
-					OrgName:      splitLine[0],
-					RepoName:     splitLine[1],
-					FullRepoName: line,
-				}
-			case 3:
-				repo = Repo{
-					Host:         splitLine[0],
-					OrgName:      splitLine[1],
-					RepoName:     splitLine[2],
-					FullRepoName: line,
-				}
-			default:
-				return nil, fmt.Errorf("unable to parse entry in %s file: %s", filename, line)
-			}
-			repos = append(repos, repo)
+		// Full-line comments and blank lines are ignored as before.
+		if strings.HasPrefix(line, "#") || len(strings.TrimSpace(line)) == 0 {
+			continue
 		}
+
+		// Split on the first '#' to separate the repo name from any trailing
+		// comment. Repo names cannot contain '#', so this split is unambiguous.
+		var repoPart, commentPart string
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			repoPart = line[:idx]
+			commentPart = line[idx+1:]
+		} else {
+			repoPart = line
+		}
+		repoPart = strings.TrimSpace(repoPart)
+		if repoPart == "" {
+			continue
+		}
+
+		splitLine := strings.Split(repoPart, "/")
+		numParts := len(splitLine)
+		var repo Repo
+		switch numParts {
+		case 2:
+			repo = Repo{
+				OrgName:      splitLine[0],
+				RepoName:     splitLine[1],
+				FullRepoName: repoPart,
+			}
+		case 3:
+			repo = Repo{
+				Host:         splitLine[0],
+				OrgName:      splitLine[1],
+				RepoName:     splitLine[2],
+				FullRepoName: repoPart,
+			}
+		default:
+			return nil, fmt.Errorf("unable to parse entry in %s file: %s", filename, line)
+		}
+
+		// Scan the trailing comment for a `branch=<value>` token. Other
+		// comment text is free-form and ignored so users can keep notes.
+		if m := branchAnnotationRegexp.FindStringSubmatch(commentPart); m != nil {
+			repo.Branch = m[1]
+		}
+
+		if existing, seen := branchByRepo[repo.FullRepoName]; seen {
+			if existing != repo.Branch {
+				return nil, fmt.Errorf("conflicting branch annotations for %s: %q vs %q", repo.FullRepoName, existing, repo.Branch)
+			}
+			continue
+		}
+		branchByRepo[repo.FullRepoName] = repo.Branch
+		repos = append(repos, repo)
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/internal/campaign/campaign_test.go
+++ b/internal/campaign/campaign_test.go
@@ -35,12 +35,14 @@ func TestItReadsSimpleRepoNamesFromReposFile(t *testing.T) {
 			OrgName:      "org",
 			RepoName:     "repo1",
 			FullRepoName: "org/repo1",
+			Branch:       campaign.Name,
 		},
 		{
 			Host:         "",
 			OrgName:      "org",
 			RepoName:     "repo2",
 			FullRepoName: "org/repo2",
+			Branch:       campaign.Name,
 		},
 	}, campaign.Repos)
 	assert.Equal(t, "PR title", campaign.PrTitle)
@@ -61,12 +63,14 @@ func TestItReadsRepoNamesWithOtherHostsFromReposFile(t *testing.T) {
 			OrgName:      "org",
 			RepoName:     "repo1",
 			FullRepoName: "org/repo1",
+			Branch:       campaign.Name,
 		},
 		{
 			Host:         "mygitserver.com",
 			OrgName:      "org",
 			RepoName:     "repo2",
 			FullRepoName: "mygitserver.com/org/repo2",
+			Branch:       campaign.Name,
 		},
 	}, campaign.Repos)
 	assert.Equal(t, "PR title", campaign.PrTitle)
@@ -87,6 +91,7 @@ func TestItIgnoresCommentedLines(t *testing.T) {
 			OrgName:      "org",
 			RepoName:     "repo1",
 			FullRepoName: "org/repo1",
+			Branch:       campaign.Name,
 		},
 	}, campaign.Repos)
 	assert.Equal(t, "PR title", campaign.PrTitle)
@@ -107,6 +112,7 @@ func TestItIgnoresEmptyLines(t *testing.T) {
 			OrgName:      "org",
 			RepoName:     "repo1",
 			FullRepoName: "org/repo1",
+			Branch:       campaign.Name,
 		},
 	}, campaign.Repos)
 	assert.Equal(t, "PR title", campaign.PrTitle)
@@ -127,6 +133,7 @@ func TestItIgnoresEmptyAndCommentedLines(t *testing.T) {
 			OrgName:      "org",
 			RepoName:     "repo1",
 			FullRepoName: "org/repo1",
+			Branch:       campaign.Name,
 		},
 	}, campaign.Repos)
 	assert.Equal(t, "PR title", campaign.PrTitle)
@@ -146,6 +153,7 @@ func TestItIgnoresDuplicatedLines(t *testing.T) {
 			OrgName:      "org",
 			RepoName:     "repo1",
 			FullRepoName: "org/repo1",
+			Branch:       campaign.Name,
 		},
 	}, campaign.Repos)
 }
@@ -163,12 +171,14 @@ func TestItIgnoresDuplicatedNonSequentialLines(t *testing.T) {
 			OrgName:      "org",
 			RepoName:     "repo1",
 			FullRepoName: "org/repo1",
+			Branch:       campaign.Name,
 		},
 		{
 			Host:         "",
 			OrgName:      "org",
 			RepoName:     "repo2",
 			FullRepoName: "org/repo2",
+			Branch:       campaign.Name,
 		},
 	}, campaign.Repos)
 }
@@ -188,18 +198,21 @@ func TestItShouldAcceptADifferentRepoFileSuccess(t *testing.T) {
 			OrgName:      "org",
 			RepoName:     "repo1",
 			FullRepoName: "org/repo1",
+			Branch:       campaign.Name,
 		},
 		{
 			Host:         "",
 			OrgName:      "org",
 			RepoName:     "repo2",
 			FullRepoName: "org/repo2",
+			Branch:       campaign.Name,
 		},
 		{
 			Host:         "",
 			OrgName:      "org",
 			RepoName:     "repo3",
 			FullRepoName: "org/repo3",
+			Branch:       campaign.Name,
 		},
 	}, campaign.Repos)
 }
@@ -251,6 +264,33 @@ func TestItShouldErrorWhenPrDescriptionFileNameIsEmpty(t *testing.T) {
 	options.PrDescriptionFilename = ""
 	_, err := OpenCampaign(options)
 	assert.Error(t, err)
+}
+
+func TestItReadsBranchAnnotationsFromReposFile(t *testing.T) {
+	testsupport.PrepareTempCampaign(false,
+		"org/repo1 # branch=feature-x",
+		"org/repo2",
+		"org/repo3 # branch=agent-fix-42 reviewer note",
+	)
+
+	campaign, err := OpenCampaign(NewCampaignOptions())
+	assert.NoError(t, err)
+
+	assert.Equal(t, []Repo{
+		{OrgName: "org", RepoName: "repo1", FullRepoName: "org/repo1", Branch: "feature-x"},
+		{OrgName: "org", RepoName: "repo2", FullRepoName: "org/repo2", Branch: campaign.Name},
+		{OrgName: "org", RepoName: "repo3", FullRepoName: "org/repo3", Branch: "agent-fix-42"},
+	}, campaign.Repos)
+}
+
+func TestItErrorsOnDuplicateRepoWithDifferentBranches(t *testing.T) {
+	testsupport.PrepareTempCampaign(false,
+		"org/repo1 # branch=foo",
+		"org/repo1 # branch=bar",
+	)
+	_, err := OpenCampaign(NewCampaignOptions())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting branch")
 }
 
 func TestBranchNamePrefixLogic(t *testing.T) {

--- a/internal/campaign/prs.go
+++ b/internal/campaign/prs.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 Skyscanner Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package campaign
+
+import (
+	"bufio"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// PRRef identifies a specific pull request by (optional host, org, repo, number).
+// Host is empty for PRs on github.com; populated for GitHub Enterprise hosts
+// discovered from URL-form input.
+type PRRef struct {
+	Host     string
+	OrgName  string
+	RepoName string
+	Number   int
+}
+
+// FullRepoName returns the org/repo identifier (without host prefix), suitable
+// for use as a key when looking up or storing repos in repos.txt. The host is
+// deliberately omitted because repos.txt lines may or may not carry the host
+// prefix — downstream callers that need it can read PRRef.Host explicitly.
+func (p PRRef) FullRepoName() string {
+	return p.OrgName + "/" + p.RepoName
+}
+
+// shorthandRegexp matches `org/repo#N`. We accept alphanumerics, dash, dot,
+// and underscore in org/repo names — the set of characters GitHub permits.
+var shorthandRegexp = regexp.MustCompile(`^([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)#(\d+)$`)
+
+// ParsePRRef accepts either a full URL (`https://host/org/repo/pull/N`) or the
+// shorthand `org/repo#N`. Returns an error for anything else — the caller is
+// responsible for surfacing malformed input to the user loudly, since silent
+// skipping would be surprising.
+func ParsePRRef(line string) (PRRef, error) {
+	line = strings.TrimSpace(line)
+
+	// URL form: parse with net/url so we correctly handle alternate hosts
+	// (GHE) and any path quirks.
+	if strings.HasPrefix(line, "http://") || strings.HasPrefix(line, "https://") {
+		u, err := url.Parse(line)
+		if err != nil {
+			return PRRef{}, fmt.Errorf("invalid PR URL %q: %w", line, err)
+		}
+		// Expect path like /org/repo/pull/N.
+		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+		if len(parts) != 4 || parts[2] != "pull" {
+			return PRRef{}, fmt.Errorf("PR URL does not look like /org/repo/pull/N: %q", line)
+		}
+		num, err := strconv.Atoi(parts[3])
+		if err != nil || num <= 0 {
+			return PRRef{}, fmt.Errorf("PR URL has no numeric PR number: %q", line)
+		}
+		host := u.Host
+		// github.com is the default — leave Host empty so downstream logic
+		// can treat "no host" and "github.com" identically.
+		if host == "github.com" {
+			host = ""
+		}
+		return PRRef{Host: host, OrgName: parts[0], RepoName: parts[1], Number: num}, nil
+	}
+
+	// Shorthand form.
+	if m := shorthandRegexp.FindStringSubmatch(line); m != nil {
+		num, _ := strconv.Atoi(m[3]) // regex guarantees digits
+		return PRRef{OrgName: m[1], RepoName: m[2], Number: num}, nil
+	}
+
+	return PRRef{}, fmt.Errorf("unrecognised PR reference %q (expected URL or org/repo#N)", line)
+}
+
+// ReadPRsFile reads a file containing one PR reference per line, skipping
+// blank lines and full-line `#` comments. Exact duplicates (same org/repo/N)
+// are silently deduped. Multiple PRs against the same repo are an error —
+// turbolift assimilates at most one PR per repo per campaign.
+func ReadPRsFile(path string) ([]PRRef, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open PRs file %s: %w", path, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	seenKey := map[string]PRRef{} // key = "org/repo"
+	var prs []PRRef
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		pr, err := ParsePRRef(line)
+		if err != nil {
+			return nil, err
+		}
+		key := pr.FullRepoName()
+		if existing, seen := seenKey[key]; seen {
+			if existing.Number == pr.Number {
+				continue // exact dup — silent skip
+			}
+			return nil, fmt.Errorf("multiple PRs for %s in %s (#%d and #%d)", key, path, existing.Number, pr.Number)
+		}
+		seenKey[key] = pr
+		prs = append(prs, pr)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("unable to read PRs file %s: %w", path, err)
+	}
+	return prs, nil
+}

--- a/internal/campaign/prs.go
+++ b/internal/campaign/prs.go
@@ -96,7 +96,7 @@ func ReadPRsFile(path string) ([]PRRef, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to open PRs file %s: %w", path, err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	seenKey := map[string]PRRef{} // key = "org/repo"

--- a/internal/campaign/prs_test.go
+++ b/internal/campaign/prs_test.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Skyscanner Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package campaign
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePRRef_GithubComURL(t *testing.T) {
+	pr, err := ParsePRRef("https://github.com/Skyscanner/turbolift/pull/215")
+	assert.NoError(t, err)
+	assert.Equal(t, PRRef{Host: "", OrgName: "Skyscanner", RepoName: "turbolift", Number: 215}, pr)
+}
+
+func TestParsePRRef_GHEURL(t *testing.T) {
+	pr, err := ParsePRRef("https://github.my-ghe.example/org/repo/pull/42")
+	assert.NoError(t, err)
+	assert.Equal(t, PRRef{Host: "github.my-ghe.example", OrgName: "org", RepoName: "repo", Number: 42}, pr)
+}
+
+func TestParsePRRef_Shorthand(t *testing.T) {
+	pr, err := ParsePRRef("Skyscanner/turbolift#216")
+	assert.NoError(t, err)
+	assert.Equal(t, PRRef{OrgName: "Skyscanner", RepoName: "turbolift", Number: 216}, pr)
+}
+
+func TestParsePRRef_Malformed(t *testing.T) {
+	_, err := ParsePRRef("not a pr ref at all")
+	assert.Error(t, err)
+}
+
+func TestParsePRRef_URLMissingNumber(t *testing.T) {
+	_, err := ParsePRRef("https://github.com/org/repo/pull/")
+	assert.Error(t, err)
+}
+
+func TestReadPRsFile_HappyPath(t *testing.T) {
+	tmp, err := os.CreateTemp("", "prs-*.txt")
+	assert.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, _ = tmp.WriteString("# a full-line comment\n\nhttps://github.com/org/repo1/pull/1\norg/repo2#2\n")
+	_ = tmp.Close()
+
+	prs, err := ReadPRsFile(tmp.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, []PRRef{
+		{OrgName: "org", RepoName: "repo1", Number: 1},
+		{OrgName: "org", RepoName: "repo2", Number: 2},
+	}, prs)
+}
+
+func TestReadPRsFile_DuplicatePRDeduped(t *testing.T) {
+	tmp, err := os.CreateTemp("", "prs-*.txt")
+	assert.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, _ = tmp.WriteString("org/repo1#1\norg/repo1#1\n")
+	_ = tmp.Close()
+
+	prs, err := ReadPRsFile(tmp.Name())
+	assert.NoError(t, err)
+	assert.Len(t, prs, 1)
+}
+
+func TestReadPRsFile_SameRepoDifferentPRsErrors(t *testing.T) {
+	tmp, err := os.CreateTemp("", "prs-*.txt")
+	assert.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, _ = tmp.WriteString("org/repo1#1\norg/repo1#2\n")
+	_ = tmp.Close()
+
+	_, err = ReadPRsFile(tmp.Name())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple PRs")
+}
+
+func TestReadPRsFile_MalformedLine(t *testing.T) {
+	tmp, err := os.CreateTemp("", "prs-*.txt")
+	assert.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	_, _ = tmp.WriteString("not a pr ref\n")
+	_ = tmp.Close()
+
+	_, err = ReadPRsFile(tmp.Name())
+	assert.Error(t, err)
+}

--- a/internal/campaign/prs_test.go
+++ b/internal/campaign/prs_test.go
@@ -52,7 +52,7 @@ func TestParsePRRef_URLMissingNumber(t *testing.T) {
 func TestReadPRsFile_HappyPath(t *testing.T) {
 	tmp, err := os.CreateTemp("", "prs-*.txt")
 	assert.NoError(t, err)
-	defer os.Remove(tmp.Name())
+	defer func() { _ = os.Remove(tmp.Name()) }()
 	_, _ = tmp.WriteString("# a full-line comment\n\nhttps://github.com/org/repo1/pull/1\norg/repo2#2\n")
 	_ = tmp.Close()
 
@@ -67,7 +67,7 @@ func TestReadPRsFile_HappyPath(t *testing.T) {
 func TestReadPRsFile_DuplicatePRDeduped(t *testing.T) {
 	tmp, err := os.CreateTemp("", "prs-*.txt")
 	assert.NoError(t, err)
-	defer os.Remove(tmp.Name())
+	defer func() { _ = os.Remove(tmp.Name()) }()
 	_, _ = tmp.WriteString("org/repo1#1\norg/repo1#1\n")
 	_ = tmp.Close()
 
@@ -79,7 +79,7 @@ func TestReadPRsFile_DuplicatePRDeduped(t *testing.T) {
 func TestReadPRsFile_SameRepoDifferentPRsErrors(t *testing.T) {
 	tmp, err := os.CreateTemp("", "prs-*.txt")
 	assert.NoError(t, err)
-	defer os.Remove(tmp.Name())
+	defer func() { _ = os.Remove(tmp.Name()) }()
 	_, _ = tmp.WriteString("org/repo1#1\norg/repo1#2\n")
 	_ = tmp.Close()
 
@@ -91,7 +91,7 @@ func TestReadPRsFile_SameRepoDifferentPRsErrors(t *testing.T) {
 func TestReadPRsFile_MalformedLine(t *testing.T) {
 	tmp, err := os.CreateTemp("", "prs-*.txt")
 	assert.NoError(t, err)
-	defer os.Remove(tmp.Name())
+	defer func() { _ = os.Remove(tmp.Name()) }()
 	_, _ = tmp.WriteString("not a pr ref\n")
 	_ = tmp.Close()
 

--- a/internal/campaign/repos_edit.go
+++ b/internal/campaign/repos_edit.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2021 Skyscanner Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package campaign
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// UpsertBranchAnnotations rewrites repos.txt so that each repo in `branches`
+// ends up annotated with its PR branch. The write is atomic in the sense that
+// if any repo already has a conflicting `branch=<other>` annotation, the
+// function returns an error WITHOUT modifying the file. Callers are expected
+// to surface conflicts to the user for manual resolution.
+//
+// Preserved verbatim: full-line comments, blank lines, the order of existing
+// lines, and any non-`branch=` text in trailing comments on matched lines.
+// Repos in `branches` that aren't already in the file are appended at the
+// end, in alphabetical order for deterministic output.
+func UpsertBranchAnnotations(path string, branches map[string]string) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("unable to read %s: %w", path, err)
+	}
+
+	// Preserve original trailing newline behaviour by splitting without
+	// stripping and handling the final empty segment specially.
+	lines := strings.Split(string(raw), "\n")
+	hasTrailingNewline := len(lines) > 0 && lines[len(lines)-1] == ""
+	if hasTrailingNewline {
+		lines = lines[:len(lines)-1]
+	}
+
+	// First pass: determine which repos we need to update and collect
+	// conflicts. No writes yet — we want all-or-nothing atomicity so a
+	// conflict doesn't leave repos.txt half-updated.
+	type update struct {
+		lineIdx    int
+		newContent string
+	}
+	var updates []update
+	remaining := make(map[string]string, len(branches))
+	for k, v := range branches {
+		remaining[k] = v
+	}
+	var conflicts []string
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// Extract the repo part (before any '#'). Same split rule as the
+		// parser: repo names cannot contain '#'.
+		var repoPart, commentPart string
+		var hadComment bool
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			repoPart = line[:idx]
+			commentPart = line[idx+1:]
+			hadComment = true
+		} else {
+			repoPart = line
+		}
+		repoKey := strings.TrimSpace(repoPart)
+
+		wantBranch, want := branches[repoKey]
+		if !want {
+			continue
+		}
+		delete(remaining, repoKey)
+
+		// Detect existing `branch=<x>` in the comment.
+		existingMatch := branchAnnotationRegexp.FindStringSubmatch(commentPart)
+		if existingMatch != nil {
+			existingBranch := existingMatch[1]
+			if existingBranch == wantBranch {
+				// Already correct — leave line untouched.
+				continue
+			}
+			conflicts = append(conflicts, fmt.Sprintf("%s: existing branch=%s, want branch=%s", repoKey, existingBranch, wantBranch))
+			continue
+		}
+
+		// Inject `branch=<wantBranch>` into the line. If there's an existing
+		// comment without a branch annotation, prepend our annotation and
+		// keep the rest of the comment text.
+		var newLine string
+		if !hadComment {
+			newLine = fmt.Sprintf("%s # branch=%s", repoKey, wantBranch)
+		} else {
+			newLine = fmt.Sprintf("%s # branch=%s%s", repoKey, wantBranch, commentPart)
+		}
+		updates = append(updates, update{lineIdx: i, newContent: newLine})
+	}
+
+	if len(conflicts) > 0 {
+		return fmt.Errorf("conflicting branch annotations in %s:\n  %s\nResolve manually and retry.", path, strings.Join(conflicts, "\n  "))
+	}
+
+	// Apply in-memory updates and append new lines for unmatched repos.
+	for _, u := range updates {
+		lines[u.lineIdx] = u.newContent
+	}
+	if len(remaining) > 0 {
+		keys := make([]string, 0, len(remaining))
+		for k := range remaining {
+			keys = append(keys, k)
+		}
+		// Sort so behaviour doesn't depend on map iteration order and
+		// subsequent runs produce deterministic diffs.
+		sort.Strings(keys)
+		for _, k := range keys {
+			lines = append(lines, fmt.Sprintf("%s # branch=%s", k, remaining[k]))
+		}
+	}
+
+	out := strings.Join(lines, "\n")
+	if hasTrailingNewline || len(remaining) > 0 {
+		out += "\n"
+	}
+
+	if err := os.WriteFile(path, []byte(out), 0o644); err != nil {
+		return fmt.Errorf("unable to write %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/campaign/repos_edit.go
+++ b/internal/campaign/repos_edit.go
@@ -109,7 +109,7 @@ func UpsertBranchAnnotations(path string, branches map[string]string) error {
 	}
 
 	if len(conflicts) > 0 {
-		return fmt.Errorf("conflicting branch annotations in %s:\n  %s\nResolve manually and retry.", path, strings.Join(conflicts, "\n  "))
+		return fmt.Errorf("conflicting branch annotations in %s (resolve manually and retry):\n  %s", path, strings.Join(conflicts, "\n  "))
 	}
 
 	// Apply in-memory updates and append new lines for unmatched repos.

--- a/internal/campaign/repos_edit.go
+++ b/internal/campaign/repos_edit.go
@@ -21,6 +21,12 @@ import (
 	"strings"
 )
 
+// isSpace is a tiny helper to avoid pulling in unicode just to check the
+// first byte of a comment for a separator.
+func isSpace(b byte) bool {
+	return b == ' ' || b == '\t'
+}
+
 // UpsertBranchAnnotations rewrites repos.txt so that each repo in `branches`
 // ends up annotated with its PR branch. The write is atomic in the sense that
 // if any repo already has a conflicting `branch=<other>` annotation, the
@@ -98,12 +104,19 @@ func UpsertBranchAnnotations(path string, branches map[string]string) error {
 
 		// Inject `branch=<wantBranch>` into the line. If there's an existing
 		// comment without a branch annotation, prepend our annotation and
-		// keep the rest of the comment text.
+		// keep the rest of the comment text. Ensure a whitespace separator
+		// between the annotation and the preserved comment — otherwise a line
+		// like `org/repo#note` would round-trip to `branch=<x>note`, causing
+		// the parser to read the branch as `<x>note`.
 		var newLine string
 		if !hadComment {
 			newLine = fmt.Sprintf("%s # branch=%s", repoKey, wantBranch)
 		} else {
-			newLine = fmt.Sprintf("%s # branch=%s%s", repoKey, wantBranch, commentPart)
+			commentSuffix := commentPart
+			if commentSuffix != "" && !isSpace(commentSuffix[0]) {
+				commentSuffix = " " + commentSuffix
+			}
+			newLine = fmt.Sprintf("%s # branch=%s%s", repoKey, wantBranch, commentSuffix)
 		}
 		updates = append(updates, update{lineIdx: i, newContent: newLine})
 	}

--- a/internal/campaign/repos_edit_test.go
+++ b/internal/campaign/repos_edit_test.go
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2021 Skyscanner Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package campaign
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func writeReposFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "repos.txt")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+func readFile(t *testing.T, p string) string {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return string(b)
+}
+
+func TestUpsertBranchAnnotations_AppendsToEmptyTemplate(t *testing.T) {
+	initial := "# List repositories to be operated upon in this file, one repo per line. e.g.\n# org/repo1\n# org/repo2\n"
+	p := writeReposFile(t, initial)
+
+	err := UpsertBranchAnnotations(p, map[string]string{
+		"org/repo1": "feature-x",
+	})
+	assert.NoError(t, err)
+
+	expected := initial + "org/repo1 # branch=feature-x\n"
+	assert.Equal(t, expected, readFile(t, p))
+}
+
+func TestUpsertBranchAnnotations_UpdatesExistingMatchingRepo(t *testing.T) {
+	initial := "# header\norg/repo1\norg/repo2\n"
+	p := writeReposFile(t, initial)
+
+	err := UpsertBranchAnnotations(p, map[string]string{
+		"org/repo1": "feature-x",
+	})
+	assert.NoError(t, err)
+
+	expected := "# header\norg/repo1 # branch=feature-x\norg/repo2\n"
+	assert.Equal(t, expected, readFile(t, p))
+}
+
+func TestUpsertBranchAnnotations_PreservesFreeFormComment(t *testing.T) {
+	initial := "org/repo1 # reviewer note\n"
+	p := writeReposFile(t, initial)
+
+	err := UpsertBranchAnnotations(p, map[string]string{
+		"org/repo1": "feature-x",
+	})
+	assert.NoError(t, err)
+
+	// The existing comment text is preserved; the branch= token is injected.
+	result := readFile(t, p)
+	assert.Contains(t, result, "branch=feature-x")
+	assert.Contains(t, result, "reviewer note")
+}
+
+func TestUpsertBranchAnnotations_IdempotentOnMatchingBranch(t *testing.T) {
+	initial := "org/repo1 # branch=feature-x\n"
+	p := writeReposFile(t, initial)
+
+	err := UpsertBranchAnnotations(p, map[string]string{
+		"org/repo1": "feature-x",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, initial, readFile(t, p))
+}
+
+func TestUpsertBranchAnnotations_ErrorsOnConflict(t *testing.T) {
+	initial := "org/repo1 # branch=feature-x\n"
+	p := writeReposFile(t, initial)
+
+	err := UpsertBranchAnnotations(p, map[string]string{
+		"org/repo1": "feature-y",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicting")
+	// File must be untouched.
+	assert.Equal(t, initial, readFile(t, p))
+}
+
+func TestUpsertBranchAnnotations_AtomicOnMixedConflicts(t *testing.T) {
+	initial := "org/repo1 # branch=existing\norg/repo2\n"
+	p := writeReposFile(t, initial)
+
+	// repo1 conflicts; repo2 would be fine. We expect NO write to happen.
+	err := UpsertBranchAnnotations(p, map[string]string{
+		"org/repo1": "different",
+		"org/repo2": "fine",
+	})
+	assert.Error(t, err)
+	assert.Equal(t, initial, readFile(t, p))
+}
+
+func TestUpsertBranchAnnotations_PreservesFullLineCommentsAndBlankLines(t *testing.T) {
+	initial := "# header comment\n\norg/repo1\n\n# mid comment\norg/repo2\n"
+	p := writeReposFile(t, initial)
+
+	err := UpsertBranchAnnotations(p, map[string]string{
+		"org/repo2": "fix",
+	})
+	assert.NoError(t, err)
+
+	expected := "# header comment\n\norg/repo1\n\n# mid comment\norg/repo2 # branch=fix\n"
+	assert.Equal(t, expected, readFile(t, p))
+}
+
+func TestUpsertBranchAnnotations_RoundTripIsIdentical(t *testing.T) {
+	initial := "# header\norg/repo1 # branch=foo\n\norg/repo2\n"
+	p := writeReposFile(t, initial)
+
+	err := UpsertBranchAnnotations(p, map[string]string{}) // no changes
+	assert.NoError(t, err)
+	assert.Equal(t, initial, readFile(t, p))
+}
+
+func TestUpsertBranchAnnotations_MissingFileErrors(t *testing.T) {
+	err := UpsertBranchAnnotations("/nonexistent/path/repos.txt", map[string]string{"org/r": "b"})
+	assert.Error(t, err)
+}

--- a/internal/campaign/repos_edit_test.go
+++ b/internal/campaign/repos_edit_test.go
@@ -17,6 +17,7 @@ package campaign
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,6 +81,29 @@ func TestUpsertBranchAnnotations_PreservesFreeFormComment(t *testing.T) {
 	result := readFile(t, p)
 	assert.Contains(t, result, "branch=feature-x")
 	assert.Contains(t, result, "reviewer note")
+}
+
+func TestUpsertBranchAnnotations_InsertsSeparatorWhenCommentHasNone(t *testing.T) {
+	// Parser accepts `org/repo#note` (no space after '#'). If we inject
+	// `branch=X` without a separator we'd get `branch=Xnote` and the parser
+	// would later read the branch as `Xnote`. Confirm we insert a space.
+	initial := "org/repo1#reviewer note\n"
+	p := writeReposFile(t, initial)
+
+	err := UpsertBranchAnnotations(p, map[string]string{"org/repo1": "feat"})
+	assert.NoError(t, err)
+
+	result := readFile(t, p)
+	// The resulting comment must have whitespace between our branch= token
+	// and the original note — the round-trip parse must yield branch="feat".
+	assert.Contains(t, result, "branch=feat ")
+	assert.Contains(t, result, "reviewer note")
+
+	// Round-trip through the parser to confirm the branch is correctly read.
+	branch := branchAnnotationRegexp.FindStringSubmatch(strings.SplitN(result, "#", 2)[1])
+	if assert.NotNil(t, branch) {
+		assert.Equal(t, "feat", branch[1])
+	}
 }
 
 func TestUpsertBranchAnnotations_IdempotentOnMatchingBranch(t *testing.T) {

--- a/internal/git/fake_git.go
+++ b/internal/git/fake_git.go
@@ -23,8 +23,25 @@ import (
 )
 
 type FakeGit struct {
-	handler func(output io.Writer, call []string) (bool, error)
-	calls   [][]string
+	handler         func(output io.Writer, call []string) (bool, error)
+	calls           [][]string
+	branchNameByDir map[string]string
+}
+
+// Calls returns the accumulated call log — useful for tests that want to
+// inspect a subset of invocations rather than the whole sequence.
+func (f *FakeGit) Calls() [][]string {
+	return f.calls
+}
+
+// SetCurrentBranchName configures FakeGit to return the given branch name
+// when GetCurrentBranchName is called with the given workingDir. Used by
+// `cmd/clone` tests to simulate a specific PR head ref per repo.
+func (f *FakeGit) SetCurrentBranchName(workingDir, branch string) {
+	if f.branchNameByDir == nil {
+		f.branchNameByDir = map[string]string{}
+	}
+	f.branchNameByDir[workingDir] = branch
 }
 
 func (f *FakeGit) Checkout(output io.Writer, workingDir string, branch string) error {
@@ -60,6 +77,22 @@ func (f *FakeGit) Pull(output io.Writer, workingDir string, remote string, branc
 	f.calls = append(f.calls, call)
 	_, err := f.handler(output, call)
 	return err
+}
+
+func (f *FakeGit) GetCurrentBranchName(output io.Writer, workingDir string) (string, error) {
+	call := []string{"getCurrentBranchName", workingDir}
+	f.calls = append(f.calls, call)
+	// If the test has configured a specific branch for this dir, return it
+	// directly without consulting the generic handler — tests typically set
+	// branches explicitly and care only about that value.
+	if b, ok := f.branchNameByDir[workingDir]; ok {
+		return b, nil
+	}
+	_, err := f.handler(output, call)
+	if err != nil {
+		return "", err
+	}
+	return "fake-branch", nil
 }
 
 func (f *FakeGit) AssertCalledWith(t *testing.T, expected [][]string) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/skyscanner/turbolift/internal/executor"
 )
@@ -31,6 +32,12 @@ type Git interface {
 	Commit(output io.Writer, workingDir string, message string) error
 	IsRepoChanged(output io.Writer, workingDir string) (bool, error)
 	Pull(output io.Writer, workingDir string, remote string, branchName string) error
+	// GetCurrentBranchName returns the name of the currently checked-out branch
+	// in workingDir. Used by `clone --from-prs` to capture a PR's branch after
+	// `gh pr checkout` has fetched and checked it out — the PR branch name may
+	// not match the campaign name, and it's simpler to read HEAD than to parse
+	// `gh` output.
+	GetCurrentBranchName(output io.Writer, workingDir string) (string, error)
 }
 
 type RealGit struct{}
@@ -70,6 +77,19 @@ func (r *RealGit) IsRepoChanged(output io.Writer, workingDir string) (bool, erro
 
 func (r *RealGit) Pull(output io.Writer, workingDir string, remote string, branchName string) error {
 	return execInstance.Execute(output, workingDir, "git", "pull", "--ff-only", remote, branchName)
+}
+
+func (r *RealGit) GetCurrentBranchName(output io.Writer, workingDir string) (string, error) {
+	// --abbrev-ref HEAD yields the short branch name if we're on a branch, or
+	// "HEAD" if detached. Detached state shouldn't happen in the clone
+	// --from-prs flow (gh pr checkout lands us on a branch) — but if it does,
+	// the caller sees "HEAD" and can decide what to do rather than silently
+	// writing "HEAD" into repos.txt.
+	name, err := execInstance.ExecuteAndCapture(output, workingDir, "git", "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(name), nil
 }
 
 func NewRealGit() *RealGit {

--- a/internal/github/fake_github.go
+++ b/internal/github/fake_github.go
@@ -89,8 +89,8 @@ func (f *FakeGitHub) ClosePullRequest(_ io.Writer, workingDir string, branchName
 	return err
 }
 
-func (f *FakeGitHub) GetPR(_ io.Writer, workingDir string, _ string) (*PrStatus, error) {
-	f.calls = append(f.calls, []string{"get_pr", workingDir})
+func (f *FakeGitHub) GetPR(_ io.Writer, workingDir string, branchName string) (*PrStatus, error) {
+	f.calls = append(f.calls, []string{"get_pr", workingDir, branchName})
 	result, err := f.returningHandler(workingDir)
 	if result == nil {
 		return nil, err

--- a/internal/github/fake_github.go
+++ b/internal/github/fake_github.go
@@ -17,6 +17,7 @@ package github
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -33,12 +34,19 @@ const (
 	GetDefaultBranchName
 	UpdatePRDescription
 	IsPushable
+	CheckoutPR
 )
 
 type FakeGitHub struct {
 	handler          func(command Command, args []string) (bool, error)
 	returningHandler func(workingDir string) (interface{}, error)
 	calls            [][]string
+}
+
+// Calls returns the accumulated call log — useful for tests that want to
+// inspect a subset of invocations rather than the whole sequence.
+func (f *FakeGitHub) Calls() [][]string {
+	return f.calls
 }
 
 func (f *FakeGitHub) CreatePullRequest(_ io.Writer, workingDir string, metadata PullRequest) (didCreate bool, err error) {
@@ -58,6 +66,13 @@ func (f *FakeGitHub) Clone(_ io.Writer, workingDir string, fullRepoName string) 
 	args := []string{"clone", workingDir, fullRepoName}
 	f.calls = append(f.calls, args)
 	_, err := f.handler(Clone, args)
+	return err
+}
+
+func (f *FakeGitHub) CheckoutPR(_ io.Writer, workingDir string, prNumber int) error {
+	args := []string{"checkout_pr", workingDir, fmt.Sprintf("%d", prNumber)}
+	f.calls = append(f.calls, args)
+	_, err := f.handler(CheckoutPR, args)
 	return err
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -172,9 +172,13 @@ func (r *RealGitHub) GetPR(output io.Writer, workingDir string, branchName strin
 		return prr.CurrentBranch, nil
 	}
 
-	// If not, then it's a forked PR. The headRefName is as such: `username:branchName`
+	// If not, then it's a forked PR. The headRefName is `username:branchName`.
+	// We require either an exact match (rare — usually the CurrentBranch path
+	// would have caught it) or the fork-style `:branchName` suffix, which
+	// avoids the foot-gun of a naive HasSuffix matching "foo-branchName"
+	// when we're actually looking for "branchName".
 	for _, pr := range prr.CreatedBy {
-		if strings.HasSuffix(pr.HeadRefName, branchName) {
+		if pr.HeadRefName == branchName || strings.HasSuffix(pr.HeadRefName, ":"+branchName) {
 			return pr, nil
 		}
 	}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -44,6 +44,12 @@ type GitHub interface {
 	GetPR(output io.Writer, workingDir string, branchName string) (*PrStatus, error)
 	GetDefaultBranchName(output io.Writer, workingDir string, fullRepoName string) (string, error)
 	IsPushable(output io.Writer, repo string) (bool, error)
+	// CheckoutPR fetches the given PR's head and checks it out as a local
+	// branch. Uses `gh pr checkout` because it correctly handles PRs from
+	// forks (configures the remote, fetches the ref, sets upstream tracking)
+	// — none of which a hand-rolled git fetch+checkout would handle without
+	// reimplementing that logic.
+	CheckoutPR(output io.Writer, workingDir string, prNumber int) error
 }
 
 type RealGitHub struct{}
@@ -80,6 +86,10 @@ func (r *RealGitHub) ForkAndClone(output io.Writer, workingDir string, fullRepoN
 
 func (r *RealGitHub) Clone(output io.Writer, workingDir string, fullRepoName string) error {
 	return execInstance.Execute(output, workingDir, "gh", "repo", "clone", fullRepoName)
+}
+
+func (r *RealGitHub) CheckoutPR(output io.Writer, workingDir string, prNumber int) error {
+	return execInstance.Execute(output, workingDir, "gh", "pr", "checkout", fmt.Sprintf("%d", prNumber))
 }
 
 func (r *RealGitHub) ClosePullRequest(output io.Writer, workingDir string, branchName string) error {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -225,3 +225,36 @@ func runUpdatePrDescriptionAndCaptureOutput() (string, error) {
 	err := NewRealGitHub().UpdatePRDescription(&sb, "work/org/repo1", "new title", "new body")
 	return sb.String(), err
 }
+
+// TestGetPR_ForkPRMatchesByExactBranch exercises the fork-PR lookup path
+// where `gh pr status` returns multiple PRs in createdBy. Under a naive
+// `strings.HasSuffix` match, a longer branch name ending with the one we're
+// looking for would match first (e.g. "foo-feat/x" contains suffix "feat/x").
+// The fix is to require either an exact match or a `user:branch` fork-style
+// suffix — i.e. the branch preceded by ':'.
+func TestGetPR_ForkPRMatchesByExactBranch(t *testing.T) {
+	// createdBy[0] has HeadRefName "someuser:foo-feat/x" — plain HasSuffix
+	// would wrongly match this for branchName "feat/x". createdBy[1] has
+	// "otheruser:feat/x" which is the correct fork-style match.
+	prStatusJSON := `{
+		"currentBranch": null,
+		"createdBy": [
+			{"number": 1, "headRefName": "someuser:foo-feat/x", "state": "OPEN"},
+			{"number": 2, "headRefName": "otheruser:feat/x", "state": "OPEN"}
+		],
+		"needsReview": []
+	}`
+	fakeExecutor := executor.NewFakeExecutor(
+		func(workingDir string, name string, args ...string) error { return nil },
+		func(workingDir string, name string, args ...string) (string, error) {
+			return prStatusJSON, nil
+		},
+	)
+	execInstance = fakeExecutor
+
+	sb := strings.Builder{}
+	pr, err := NewRealGitHub().GetPR(&sb, "work/org/repo1", "feat/x")
+	assert.NoError(t, err)
+	assert.NotNil(t, pr)
+	assert.Equal(t, 2, pr.Number, "should match the PR whose branch is exactly feat/x (preceded by ':'), not the one that merely ends in feat/x")
+}


### PR DESCRIPTION
## Summary

Closes #215.

Adds `turbolift clone --from-prs <file>` to assimilate existing PRs (e.g. PRs raised by cloud agents or teammates) in a single command — instead of the current manual `git checkout` dance.

- **`prs.txt`** accepts either `https://host/org/repo/pull/N` URLs or `org/repo#N` shorthand, one per line.
- **`repos.txt`** gains a `# branch=<name>` annotation syntax so PR head branches (which may differ from the campaign name, and from each other) are recorded per-repo.
- **Downstream commands** (`create-prs`, `update-prs --push/--close`, `pr-status`) now use `repo.Branch` — in the normal flow this defaults to the campaign name, so behaviour is unchanged for non-assimilation campaigns.
- **`gh pr checkout`** is used after cloning, so PRs from forks work transparently (sets up remote, fetches ref, configures upstream tracking).
- **`UpsertBranchAnnotations`** is atomic — if an existing annotation conflicts, it errors without touching `repos.txt`, leaving manual resolution to the user.
- **Small bug fix** along the way: `GetPR` used a naive `HasSuffix` match on fork-style `user:branch` head refs; tightened to require either exact or `:branch` suffix to avoid false matches. Surfaced by the `update-prs --close` flow on assimilated forked PRs.

Usage:

```shell
turbolift init --name assimilation
cd turbolift-assimilation
cat > prs.txt <<'PRS'
https://github.com/org/repo1/pull/42
org/repo2#7
PRS
turbolift clone --from-prs prs.txt
# ...edit...
turbolift commit --message "Fix follow-up review feedback"
turbolift update-prs --push
```

## Test plan

- [x] `mise run test` (lint + race/cover tests) — green
- [x] `mise run build` — binary builds
- [x] `turbolift clone --help` shows the new flag cleanly
- [ ] Manual smoke test against a real repo with an open PR (reviewer / author may want to exercise this)

## Design & plan

- Design spec: `docs/superpowers/specs/2026-04-27-assimilate-existing-prs-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-27-assimilate-existing-prs.md`

## Notes for reviewers

- No new top-level `push` command — existing `update-prs --push` now works on assimilated branches (see commit 6).
- No state file / sidecar config. Branch metadata lives in `repos.txt` as trailing comments, so it round-trips cleanly and users can hand-edit it.
- `--from-prs` and `--repos` are mutually exclusive to keep semantics unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)